### PR TITLE
Extendable contract storages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Pierre-Emmanuel Wulfman, Sander Spies, Melwyn Saldanha and ligolang.
+Copyright (c) 2021-2023 the LigoLang team.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,3 @@ endif
 
 lint: ## lint code
 	@npx eslint ./scripts --ext .ts
-
-sandbox-start: ## start sandbox
-	@./scripts/run-sandbox
-
-sandbox-stop: ## stop sandbox
-	@docker stop sandbox

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ export type storage = {
 
 type ret = [list<operation>, storage];
 
-import Contract = FA2.NFT
+import Contract = Contract.NFT
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     Single Asset Token where a different amount of single token can belong to multiple
     addresses at a time (1:n)
   - [Multiple Assets](./lib/fa2/asset/multi_asset.impl.mligo): This is an implementation of
-    Multi Asset Token where there are many tokens (available in different amounts)
+    Multi Asset Token where there are several token ids (available in different amounts)
     and they can belong to multiple addresses (m:n)
 
 ## Use the implementation directly
@@ -47,15 +47,19 @@ export type storage = {
     ledger: Contract.NFT.ledger,
     metadata: Contract.TZIP16.metadata,
     token_metadata: Contract.TZIP12.tokenMetadata,
-    operators: Contract.NFT.operators
+    operators: Contract.NFT.operators,
+    extension: unit
 };
 
 type ret = [list<operation>, storage];
+
+import Contract = FA2.NFT
+
 ```
 
-Importing the library allows you to add TZIP types to your custom storage
+Importing the library allows you to add TZIP types to your custom storage.
 
-Add the TZIP12 default entrypoints, calling the functions of the library and mapping it to your custom storage
+Add the TZIP12 default entrypoints, calling the functions of the library and mapping it to your custom storage. For instance, to reimplement the `transfer` entrypoint, do:
 
 ```ligolang
 @entry
@@ -68,6 +72,7 @@ const transfer = (p: Contract.TZIP12.transfer, s: storage): ret => {
                 metadata: s.metadata,
                 token_metadata: s.token_metadata,
                 operators: s.operators,
+                extension: unit
             }
         );
     return [
@@ -78,60 +83,13 @@ const transfer = (p: Contract.TZIP12.transfer, s: storage): ret => {
             metadata: ret2[1].metadata,
             token_metadata: ret2[1].token_metadata,
             operators: ret2[1].operators,
-        }
-    ]
-};
-
-@entry
-const balance_of = (p: Contract.TZIP12.balance_of, s: storage): ret => {
-    const ret2: [list<operation>, Contract.NFT.storage] =
-        Contract.NFT.balance_of(
-            p,
-            {
-                ledger: s.ledger,
-                metadata: s.metadata,
-                token_metadata: s.token_metadata,
-                operators: s.operators,
-            }
-        );
-    return [
-        ret2[0],
-        {
-            ...s,
-            ledger: ret2[1].ledger,
-            metadata: ret2[1].metadata,
-            token_metadata: ret2[1].token_metadata,
-            operators: ret2[1].operators
-        }
-    ]
-};
-
-@entry
-const update_operators = (p: Contract.TZIP12.update_operators, s: storage): ret => {
-    const ret2: [list<operation>, Contract.NFT.storage] =
-        Contract.NFT.update_operators(
-            p,
-            {
-                ledger: s.ledger,
-                metadata: s.metadata,
-                token_metadata: s.token_metadata,
-                operators: s.operators
-            }
-        );
-    return [
-        ret2[0],
-        {
-            ...s,
-            ledger: ret2[1].ledger,
-            metadata: ret2[1].metadata,
-            token_metadata: ret2[1].token_metadata,
-            operators: ret2[1].operators
+            extension: unit
         }
     ]
 };
 ```
 
-Continue to add non-TZIP new entrypoints, etc ...
+See the `examples/marketplace.jsligo` file for a complete example.
 
 ## Implement the interface differently
 

--- a/examples/marketplace.jsligo
+++ b/examples/marketplace.jsligo
@@ -1,11 +1,17 @@
-#import "../lib/fa2/nft/nft.impl.jsligo" "Contract"
+#import "../lib/main.mligo" "FA2"
+
+import Contract = FA2.NFT
+
+// FIXME These files make no sense and should probably be removed
+// but here we're just showcasing how to import the library
 
 export type storage = {
     administrators: set<address>,
     ledger: Contract.NFT.ledger,
     metadata: Contract.TZIP16.metadata,
     token_metadata: Contract.TZIP12.tokenMetadata,
-    operators: Contract.NFT.operators
+    operators: Contract.NFT.operators,
+    extension: unit
 };
 
 type ret = [list<operation>, storage];
@@ -20,6 +26,7 @@ const transfer = (p: Contract.TZIP12.transfer, s: storage): ret => {
                 metadata: s.metadata,
                 token_metadata: s.token_metadata,
                 operators: s.operators,
+                extension: unit
             }
         );
     return [
@@ -30,6 +37,7 @@ const transfer = (p: Contract.TZIP12.transfer, s: storage): ret => {
             metadata: ret2[1].metadata,
             token_metadata: ret2[1].token_metadata,
             operators: ret2[1].operators,
+            extension: unit
         }
     ]
 };
@@ -44,6 +52,7 @@ const balance_of = (p: Contract.TZIP12.balance_of, s: storage): ret => {
                 metadata: s.metadata,
                 token_metadata: s.token_metadata,
                 operators: s.operators,
+                extension: unit
             }
         );
     return [
@@ -53,7 +62,8 @@ const balance_of = (p: Contract.TZIP12.balance_of, s: storage): ret => {
             ledger: ret2[1].ledger,
             metadata: ret2[1].metadata,
             token_metadata: ret2[1].token_metadata,
-            operators: ret2[1].operators
+            operators: ret2[1].operators;
+            extension: unit
         }
     ]
 };
@@ -67,7 +77,8 @@ const update_operators = (p: Contract.TZIP12.update_operators, s: storage): ret 
                 ledger: s.ledger,
                 metadata: s.metadata,
                 token_metadata: s.token_metadata,
-                operators: s.operators
+                operators: s.operators,
+                extension: unit
             }
         );
     return [
@@ -77,7 +88,8 @@ const update_operators = (p: Contract.TZIP12.update_operators, s: storage): ret 
             ledger: ret2[1].ledger,
             metadata: ret2[1].metadata,
             token_metadata: ret2[1].token_metadata,
-            operators: ret2[1].operators
+            operators: ret2[1].operators,
+            extension: unit
         }
     ]
 };

--- a/examples/myTzip12NFTImplementation.jsligo
+++ b/examples/myTzip12NFTImplementation.jsligo
@@ -16,7 +16,8 @@ export namespace NFT implements TZIP12Interface.FA2{
         ledger: ledger,
         operators: operators,
         token_metadata: TZIP12.tokenMetadata,
-        metadata: TZIP16.metadata
+        metadata: TZIP16.metadata,
+        extension: unit
     };
     type ret = [list<operation>, storage];
     @entry

--- a/examples/myTzip12NFTImplementation.jsligo
+++ b/examples/myTzip12NFTImplementation.jsligo
@@ -32,4 +32,29 @@ export namespace NFT implements TZIP12Interface.FA2{
     const update_operators = (p: TZIP12.update_operators, s: storage): ret => {
         failwith("TODO");
     };
+
+    @view
+    const get_balance = (p: [address, nat], s: storage): nat => {
+        failwith("TODO");
+    }
+
+    @view
+    const total_supply = (token_id: nat, s: storage): nat => {
+        failwith("TODO");
+    }
+
+    @view
+    const all_tokens = (_: unit, s: storage): set<nat> => {
+        failwith("TODO");
+    }
+
+    @view
+    const is_operator = (op: TZIP12.operator, s: storage): bool => {
+        failwith("TODO");
+    }
+
+    @view
+    const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData => {
+        failwith("TODO");
+    }
 }

--- a/lib/fa2/asset/multi_asset.impl.jsligo
+++ b/lib/fa2/asset/multi_asset.impl.jsligo
@@ -8,17 +8,18 @@
 
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
-export namespace MultiAsset implements TZIP12Interface.FA2{
+export namespace MultiAssetExtendable {
    export type ledger = big_map<[address, nat], nat>;
    export type operator = address;
    export type operators = big_map<[address, operator], set<nat>>;
-   export type storage = {
+   export type storage<T> = {
       ledger: ledger,
       operators: operators,
       token_metadata: TZIP12.tokenMetadata,
-      metadata: TZIP16.metadata
+      metadata: TZIP16.metadata,
+      extension: T
    };
-   type ret = [list<operation>, storage];
+   type ret<T> = [list<operation>, storage<T>];
    //operators
 
    export const assert_authorisation = (
@@ -92,7 +93,7 @@ export namespace MultiAsset implements TZIP12Interface.FA2{
          return Big_map.update([owner, operator], auth_tokens, operators)
       }
    }
-   // ledger 
+   // ledger
 
    export const get_for_user = (
       [ledger, owner, token_id]: [ledger, address, nat]
@@ -122,15 +123,15 @@ export namespace MultiAsset implements TZIP12Interface.FA2{
       balance_ = balance_ + amount_;
       return set_for_user([ledger, to_, token_id, balance_])
    }
-   // storage 
+   // storage
 
-   export const set_ledger = ([s, ledger]: [storage, ledger]): storage =>
+   export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
       ({ ...s, ledger: ledger });
-   export const get_operators = (s: storage): operators => s.operators;
-   export const set_operators = ([s, operators]: [storage, operators]): storage =>
+   export const get_operators = <T>(s: storage<T>): operators => s.operators;
+   export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
       ({ ...s, operators: operators })
-   @entry
-   const transfer = (t: TZIP12.transfer, s: storage): [list<operation>, storage] => {
+
+   export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
       const process_atomic_transfer = (from_: address) =>
          ([l, t]: [ledger, TZIP12.atomic_trans]): ledger => {
             const { to_, token_id, amount } = t;
@@ -150,11 +151,8 @@ export namespace MultiAsset implements TZIP12Interface.FA2{
       const ledger = List.fold_left(process_single_transfer, s.ledger, t);
       return [list([]), set_ledger([s, ledger])]
    };
-   @entry
-   const balance_of = (b: TZIP12.balance_of, s: storage): [
-      list<operation>,
-      storage
-   ] => {
+
+   export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
       const { requests, callback } = b;
       const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
          const { owner, token_id } = request;
@@ -167,11 +165,8 @@ export namespace MultiAsset implements TZIP12Interface.FA2{
          Tezos.transaction(Main(callback_param), 0mutez, callback);
       return [list([operation]), s]
    };
-   @entry
-   const update_operators = (updates: TZIP12.update_operators, s: storage): [
-      list<operation>,
-      storage
-   ] => {
+
+   export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
       const update_operator = (
          [operators, update]: [operators, TZIP12.unit_update]
       ): operators =>
@@ -200,8 +195,8 @@ export namespace MultiAsset implements TZIP12Interface.FA2{
       const store = set_operators([s, operators]);
       return [list([]), store]
    };
-   @view
-   const get_balance = (p: [address, nat], s: storage): nat => {
+
+   export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
       const [owner, token_id] = p;
       Assertions.assert_token_exist(s.token_metadata, token_id);
       return match(Big_map.find_opt([owner, token_id], s.ledger)) {
@@ -211,14 +206,14 @@ export namespace MultiAsset implements TZIP12Interface.FA2{
             n
       }
    };
-   @view
-   const total_supply = (_token_id: nat, _s: storage): nat =>
+
+   export const total_supply = <T>(_token_id: nat, _s: storage<T>): nat =>
       failwith(Errors.not_available);
-   @view
-   const all_tokens = (_: unit, _s: storage): set<nat> =>
+
+   export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
       failwith(Errors.not_available);
-   @view
-   const is_operator = (op: TZIP12.operator, s: storage): bool => {
+
+   export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
       const authorized =
          match(Big_map.find_opt([op.owner, op.operator], s.operators)) {
             when (Some(opSet)):
@@ -228,8 +223,8 @@ export namespace MultiAsset implements TZIP12Interface.FA2{
          };
       return (Set.size(authorized) > 0n || op.owner == op.operator)
    };
-   @view
-   const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData => {
+
+   export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
       return match(Big_map.find_opt(p, s.token_metadata)) {
          when (Some(data)):
             data
@@ -238,3 +233,43 @@ export namespace MultiAsset implements TZIP12Interface.FA2{
       }
    };
 };
+
+export namespace MultiAsset implements TZIP12Interface.FA2 {
+  export type ledger = MultiAssetExtendable.ledger;
+  export type operator = MultiAssetExtendable.operator;
+  export type operators = MultiAssetExtendable.operators;
+  export type storage = MultiAssetExtendable.storage<unit>;
+  type ret = [list<operation>, storage];
+
+  @entry
+  const transfer = (t: TZIP12.transfer, s: storage): ret =>
+    MultiAssetExtendable.transfer(t, s)
+
+  @entry
+  const balance_of = (b: TZIP12.balance_of, s: storage): ret =>
+    MultiAssetExtendable.balance_of(b, s)
+
+  @entry
+  const update_operators = (updates: TZIP12.update_operators, s: storage): ret =>
+    MultiAssetExtendable.update_operators(updates, s)
+
+  @view
+  const get_balance = (p: [address, nat], s: storage): nat =>
+    MultiAssetExtendable.get_balance(p, s)
+
+  @view
+  const total_supply = (token_id: nat, s: storage): nat =>
+    MultiAssetExtendable.total_supply(token_id, s)
+
+  @view
+  const all_tokens = (_: unit, s: storage): set<nat> =>
+    MultiAssetExtendable.all_tokens(unit, s)
+
+  @view
+  const is_operator = (op: TZIP12.operator, s: storage): bool =>
+    MultiAssetExtendable.is_operator(op, s)
+
+  @view
+  const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData =>
+    MultiAssetExtendable.token_metadata(p, s)
+}

--- a/lib/fa2/asset/single_asset.impl.jsligo
+++ b/lib/fa2/asset/single_asset.impl.jsligo
@@ -8,18 +8,19 @@
 
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
-export namespace SingleAsset implements TZIP12Interface.FA2{
+export namespace SingleAssetExtendable {
    export type ledger = big_map<address, nat>;
    export type operator = address;
    export type operators = big_map<address, set<operator>>;
-   export type storage = {
+   export type storage<T> = {
       ledger: ledger,
       operators: operators,
       token_metadata: TZIP12.tokenMetadata,
-      metadata: TZIP16.metadata
+      metadata: TZIP16.metadata,
+      extension: T
    };
-   type ret = [list<operation>, storage];
-   // operators 
+   type ret<T> = [list<operation>, storage<T>];
+   // operators
 
    export const assert_authorisation = (operators: operators, from_: address): unit => {
       const sender_ = Tezos.get_sender();
@@ -74,7 +75,7 @@ export namespace SingleAsset implements TZIP12Interface.FA2{
          return Big_map.update(owner, auths, operators)
       }
    }
-   // ledger 
+   // ledger
 
    export const get_for_user = (ledger: ledger, owner: address): nat =>
       match(Big_map.find_opt(owner, ledger)) {
@@ -104,17 +105,17 @@ export namespace SingleAsset implements TZIP12Interface.FA2{
       tokens = tokens + amount_;
       return update_for_user(ledger, to_, tokens)
    }
-   // Storage 
+   // Storage
 
-   export const get_amount_for_owner = (s: storage, owner: address) =>
+   export const get_amount_for_owner = <T>(s: storage<T>, owner: address) =>
       get_for_user(s.ledger, owner);
-   export const set_ledger = (s: storage, ledger: ledger) =>
+   export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
       ({ ...s, ledger: ledger });
-   export const get_operators = (s: storage) => s.operators;
-   export const set_operators = (s: storage, operators: operators) =>
+   export const get_operators = <T>(s: storage<T>): operators => s.operators;
+   export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
       ({ ...s, operators: operators })
-   @entry
-   const transfer = (t: TZIP12.transfer, s: storage): [list<operation>, storage] => {
+
+    export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
       /* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se */
 
       const process_atomic_transfer = (from_: address) =>
@@ -132,17 +133,13 @@ export namespace SingleAsset implements TZIP12Interface.FA2{
          return List.fold_left(process_atomic_transfer(from_), ledger, txs)
       };
       const ledger = List.fold_left(process_single_transfer, s.ledger, t);
-      const store = set_ledger(s, ledger);
+      const store = set_ledger([s, ledger]);
       return [list([]), store]
    };
    /** balance_of entrypoint
 */
 
-   @entry
-   const balance_of = (b: TZIP12.balance_of, s: storage): [
-      list<operation>,
-      storage
-   ] => {
+   export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
       const { requests, callback } = b;
       const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
          const { owner, token_id } = request;
@@ -174,11 +171,7 @@ operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
 
 */
 
-   @entry
-   const update_operators = (updates: TZIP12.update_operators, s: storage): [
-      list<operation>,
-      storage
-   ] => {
+   export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
       const update_operator = (
          [operators, update]: [operators, TZIP12.unit_update]
       ): operators =>
@@ -190,11 +183,11 @@ operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
          };
       const operators =
          List.fold_left(update_operator, get_operators(s), updates);
-      const store = set_operators(s, operators);
+      const store = set_operators([s, operators]);
       return [list([]), store]
    };
-   @view
-   const get_balance = (p: [address, nat], s: storage): nat => {
+
+   export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
       const [owner, token_id] = p;
       Assertions.assert_token_exist(s.token_metadata, token_id);
       return match(Big_map.find_opt(owner, s.ledger)) {
@@ -204,14 +197,14 @@ operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
             n
       }
    };
-   @view
-   const total_supply = (_token_id: nat, _s: storage): nat =>
+
+   export const total_supply = <T>(_token_id: nat, _s: storage<T>): nat =>
       failwith(Errors.not_available);
-   @view
-   const all_tokens = (_: unit, _s: storage): set<nat> =>
+
+   export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
       failwith(Errors.not_available);
-   @view
-   const is_operator = (op: TZIP12.operator, s: storage): bool => {
+
+   export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
       const authorized =
          match(Big_map.find_opt(op.owner, s.operators)) {
             when (Some(opSet)):
@@ -221,8 +214,8 @@ operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
          };
       return (Set.mem(op.operator, authorized) || op.owner == op.operator)
    };
-   @view
-   const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData => {
+
+   export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
       return match(Big_map.find_opt(p, s.token_metadata)) {
          when (Some(data)):
             data
@@ -231,3 +224,43 @@ operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
       }
    };
 };
+
+export namespace SingleAsset implements TZIP12Interface.FA2 {
+  export type ledger = SingleAssetExtendable.ledger;
+  export type operator = SingleAssetExtendable.operator;
+  export type operators = SingleAssetExtendable.operators;
+  export type storage = SingleAssetExtendable.storage<unit>;
+  type ret = [list<operation>, storage];
+
+  @entry
+  const transfer = (t: TZIP12.transfer, s: storage): ret =>
+    SingleAssetExtendable.transfer(t, s)
+
+  @entry
+  const balance_of = (b: TZIP12.balance_of, s: storage): ret =>
+    SingleAssetExtendable.balance_of(b, s)
+
+  @entry
+  const update_operators = (updates: TZIP12.update_operators, s: storage): ret =>
+    SingleAssetExtendable.update_operators(updates, s)
+
+  @view
+  const get_balance = (p: [address, nat], s: storage): nat =>
+    SingleAssetExtendable.get_balance(p, s)
+
+  @view
+  const total_supply = (token_id: nat, s: storage): nat =>
+    SingleAssetExtendable.total_supply(token_id, s)
+
+  @view
+  const all_tokens = (_: unit, s: storage): set<nat> =>
+    SingleAssetExtendable.all_tokens(unit, s)
+
+  @view
+  const is_operator = (op: TZIP12.operator, s: storage): bool =>
+    SingleAssetExtendable.is_operator(op, s)
+
+  @view
+  const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData =>
+    SingleAssetExtendable.token_metadata(p, s)
+}

--- a/lib/fa2/common/tzip12.datatypes.jsligo
+++ b/lib/fa2/common/tzip12.datatypes.jsligo
@@ -2,20 +2,20 @@
  * Token-specific metadata is stored/presented as a Michelson value of type
  * (map string bytes).  A few of the keys are reserved and predefined by
  * TZIP-012:
- * 
- * 
+ *
+ *
  * "" (empty-string): should correspond to a TZIP-016 URI which points to a JSON
  * representation of the token metadata.
- * 
+ *
  * "name": should be a UTF-8 string giving a “display name” to the token.
- * 
+ *
  * "symbol": should be a UTF-8 string for the short identifier of the token
  * (e.g. XTZ, EUR, …).
- * 
+ *
  * "decimals": should be an integer (converted to a UTF-8 string in decimal)
  * which defines the position of the decimal point in token balances for display
  * purposes.
- * 
+ *
  * In the case of a TZIP-016 URI pointing to a JSON blob, the JSON preserves the
  * same 3 reserved non-empty fields:
  * { "symbol": <string>, "name": <string>, "decimals": <number>, ... }
@@ -49,7 +49,7 @@ export type atomic_trans = { to_: address, token_id: nat, amount: nat };
 
 export type transfer_from = { from_: address, txs: list<atomic_trans> };
 
-/** 
+/**
 * Transfer entrypoint parameter
 * A batch of transaction represented by a list of @see transfer_from
 **/
@@ -91,7 +91,7 @@ export type balance_of = {
 export type operator = { owner: address, operator: address, token_id: nat };
 
 /**
-* Add or Remove token operators variant with an @see operator update  
+* Add or Remove token operators variant with an @see operator update
 **/
 
 export type unit_update =

--- a/lib/fa2/common/tzip12.interfaces.jsligo
+++ b/lib/fa2/common/tzip12.interfaces.jsligo
@@ -3,12 +3,12 @@
 #import "tzip16.datatypes.jsligo" "TZIP16Datatypes"
 
 export interface FA2 {
-  /** The ledger stores user<->token ownership 
+  /** The ledger stores user<->token ownership
  * @see storage.ledger
   **/
 
   type ledger;
-  /** A group of operators. An operator is a Tezos address that originates token transfer operation on behalf of the owner. 
+  /** A group of operators. An operator is a Tezos address that originates token transfer operation on behalf of the owner.
    * @see storage.operators
   **/
 
@@ -19,7 +19,8 @@ export interface FA2 {
     ledger: ledger,
     operators: operators,
     token_metadata: TZIP12Datatypes.tokenMetadata,
-    metadata: TZIP16Datatypes.metadata
+    metadata: TZIP16Datatypes.metadata,
+    extension: unit
   };
   type ret = [list<operation>, storage];
   /**
@@ -39,66 +40,66 @@ export interface FA2 {
   *  Core Transfer Behavior
   *  FA2 token contracts MUST always implement this behavior.
   *
-  * 
+  *
   * - Every transfer operation MUST happen atomically and in order. If at least one
   * transfer in the batch cannot be completed, the whole transaction MUST fail, all
   * token transfers MUST be reverted, and token balances MUST remain unchanged.
-  * 
-  * 
+  *
+  *
   * - Each transfer in the batch MUST decrement token balance of the source (from_)
   * address by the amount of the transfer and increment token balance of the destination
   * (to_) address by the amount of the transfer.
-  * 
-  * 
+  *
+  *
   * - If the transfer amount exceeds current token balance of the source address,
   * the whole transfer operation MUST fail with the error mnemonic "FA2_INSUFFICIENT_BALANCE".
-  * 
-  * 
+  *
+  *
   * - If the token owner does not hold any tokens of type token_id, the owner's balance
   * is interpreted as zero. No token owner can have a negative balance.
-  * 
-  * 
+  *
+  *
   * - The transfer MUST update token balances exactly as the operation
   * parameters specify it. Transfer operations MUST NOT try to adjust transfer
   * amounts or try to add/remove additional transfers like transaction fees.
-  * 
-  * 
+  *
+  *
   * - Transfers of zero amount MUST be treated as normal transfers.
-  * 
-  * 
+  *
+  *
   * - Transfers with the same address (from_ equals to_) MUST be treated as normal
   * transfers.
-  * 
-  * 
+  *
+  *
   * -If one of the specified token_ids is not defined within the FA2 contract, the
   * entrypoint MUST fail with the error mnemonic "FA2_TOKEN_UNDEFINED".
-  * 
-  * 
+  *
+  *
   * - Transfer implementations MUST apply transfer permission policy logic (either
   * default transfer permission policy or
   * customized one).
   * If permission logic rejects a transfer, the whole operation MUST fail.
-  * 
-  * 
+  *
+  *
   * - Core transfer behavior MAY be extended. If additional constraints on tokens
   * transfer are required, FA2 token contract implementation MAY invoke additional
   * permission policies. If the additional permission fails, the whole transfer
   * operation MUST fail with a custom error mnemonic.
-  * 
-  * 
-  * 
+  *
+  *
+  *
   * Default Transfer Permission Policy
-  * 
-  * 
+  *
+  *
   * - Token owner address MUST be able to perform a transfer of its own tokens (e. g.
   * SENDER equals to from_ parameter in the transfer).
-  * 
-  * 
+  *
+  *
   * - An operator (a Tezos address that performs token transfer operation on behalf
   * of the owner) MUST be permitted to manage the specified owner's tokens before
   * it invokes a transfer transaction (see update_operators).
-  * 
-  * 
+  *
+  *
   * - If the address that invokes a transfer operation is neither a token owner nor
   * one of the permitted operators, the transaction MUST fail with the error mnemonic
   * "FA2_NOT_OPERATOR". If at least one of the transfers in the batch is not permitted,
@@ -113,16 +114,16 @@ export interface FA2 {
   * Gets the balance of multiple account/token pairs. Accepts a list of
   * balance_of_requests and a callback contract callback which accepts a list of
   * balance_of_response records.
-  * 
-  * 
+  *
+  *
   * - There may be duplicate balance_of_request's, in which case they should not be
   * deduplicated nor reordered.
-  * 
-  * 
+  *
+  *
   * - If the account does not hold any tokens, the account
   * balance is interpreted as zero.
-  * 
-  * 
+  *
+  *
   * - If one of the specified token_ids is not defined within the FA2 contract, the
   * entrypoint MUST fail with the error mnemonic "FA2_TOKEN_UNDEFINED".
   * @param p : @see TZIP12Datatypes.balance_of
@@ -133,21 +134,21 @@ export interface FA2 {
   const balance_of: (p: TZIP12Datatypes.balance_of, s: storage) => ret;
   /**
   * Add or Remove token operators for the specified token owners and token IDs.
-  * 
-  * 
+  *
+  *
   * - The entrypoint accepts a list of update_operator commands. If two different
   * commands in the list add and remove an operator for the same token owner and
   * token ID, the last command in the list MUST take effect.
-  * 
-  * 
+  *
+  *
   * - It is possible to update operators for a token owner that does not hold any token
   * balances yet.
-  * 
-  * 
+  *
+  *
   * - Operator relation is not transitive. If C is an operator of B and if B is an
   * operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
-  * 
-  * 
+  *
+  *
   * The standard does not specify who is permitted to update operators on behalf of
   * the token owner. Depending on the business use case, the particular implementation
   * of the FA2 contract MAY limit operator updates to a token owner (owner == SENDER)
@@ -186,6 +187,5 @@ the contract does not have a %token_metadata big-map
   **/
 
   @view
-  const token_metadata: (p: nat, s: storage) => TZIP12Datatypes.
-  tokenMetadataData;
+  const token_metadata: (p: nat, s: storage) => TZIP12Datatypes.tokenMetadataData;
 };

--- a/lib/fa2/nft/nft.impl.jsligo
+++ b/lib/fa2/nft/nft.impl.jsligo
@@ -8,17 +8,19 @@
 
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
-export namespace NFT implements TZIP12Interface.FA2{
+export namespace NFTExtendable {
    export type ledger = big_map<nat, address>;
-   export type operators = big_map<[address, address], set<nat>>; //[owner,operator]
+   export type operator = address;
+   export type operators = big_map<[address, operator], set<nat>>; //[owner,operator]
 
-   export type storage = {
+   export type storage<T> = {
       ledger: ledger,
       operators: operators,
       token_metadata: TZIP12.tokenMetadata,
-      metadata: TZIP16.metadata
+      metadata: TZIP16.metadata,
+      extension: T
    };
-   type ret = [list<operation>, storage];
+   type ret<T> = [list<operation>, storage<T>];
    //** LIGOFA_NFT
 
    export const assert_authorisation = (
@@ -94,7 +96,7 @@ export namespace NFT implements TZIP12Interface.FA2{
          return Big_map.update([owner, operator], auth_tokens, operators)
       }
    }
-   //  ledger 
+   //  ledger
 
    export const is_owner_of = (ledger: ledger, token_id: nat, owner: address): bool => {
       const current_owner = Option.unopt(Big_map.find_opt(token_id, ledger));
@@ -118,22 +120,23 @@ export namespace NFT implements TZIP12Interface.FA2{
       assert_owner_of(ledger, token_id, from_);
       return Big_map.update(token_id, Some(to_), ledger)
    }
-   export const set_ledger = (s: storage, ledger: ledger): storage =>
+
+   export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
       ({ ...s, ledger: ledger });
-   export const get_operators = (s: storage): operators => s.operators;
-   export const set_operators = (s: storage, operators: operators): storage =>
-      ({ ...s, operators: operators });
+   export const get_operators = <T>(s: storage<T>): operators => s.operators;
+   export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
+      ({ ...s, operators: operators })
+
    //** TZIP12Interface.FA2
-   //  operators 
+   //  operators
    /**
 * Check if the intented transfer is sent from the same sender as from field, otherwise check if the sender is part of the operator authorized to receive this token
 * @param operators :  operator bigmap
 * @param from_ : transfer from address
-* @param token_id : token_id to test  
+* @param token_id : token_id to test
 */
 
-   @entry
-   const transfer = (t: TZIP12.transfer, s: storage): ret => {
+   export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
       const process_atomic_transfer = (from_: address) =>
          ([ledger, t]: [ledger, TZIP12.atomic_trans]): ledger => {
             const { to_, token_id, amount } = t;
@@ -154,11 +157,11 @@ export namespace NFT implements TZIP12Interface.FA2{
          return List.fold_left(process_atomic_transfer(from_), ledger, txs)
       };
       const ledger = List.fold_left(process_single_transfer, s.ledger, t);
-      const store = set_ledger(s, ledger);
+      const store = set_ledger([s, ledger]);
       return [list([]), store]
    };
-   @entry
-   const balance_of = (b: TZIP12.balance_of, s: storage): ret => {
+
+   export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
       const { requests, callback } = b;
       const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
          const { owner, token_id } = request;
@@ -172,8 +175,8 @@ export namespace NFT implements TZIP12Interface.FA2{
          Tezos.transaction(Main(callback_param), 0mutez, callback);
       return [list([operation]), s]
    };
-   @entry
-   const update_operators = (updates: TZIP12.update_operators, s: storage): ret => {
+
+   export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
       const update_operator = (
          [operators, update]: [operators, TZIP12.unit_update]
       ): operators =>
@@ -195,11 +198,11 @@ export namespace NFT implements TZIP12Interface.FA2{
          };
       let operators = get_operators(s);
       operators = List.fold_left(update_operator, operators, updates);
-      const store = set_operators(s, operators);
+      const store = set_operators([s, operators]);
       return [list([]), store]
    };
-   @view
-   const get_balance = (p: [address, nat], s: storage): nat => {
+
+   export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
       const [owner, token_id] = p;
       Assertions.assert_token_exist(s.token_metadata, token_id);
       if (is_owner_of(s.ledger, token_id, owner)) {
@@ -208,16 +211,16 @@ export namespace NFT implements TZIP12Interface.FA2{
          return 0n
       }
    };
-   @view
-   const total_supply = (token_id: nat, s: storage): nat => {
+
+   export const total_supply = <T>(token_id: nat, s: storage<T>): nat => {
       Assertions.assert_token_exist(s.token_metadata, token_id);
       return 1n
    };
-   @view
-   const all_tokens = (_: unit, _s: storage): set<nat> =>
+
+   export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
       failwith(Errors.not_available);
-   @view
-   const is_operator = (op: TZIP12.operator, s: storage): bool => {
+
+   export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
       const authorized =
          match(Big_map.find_opt([op.owner, op.operator], s.operators)) {
             when (Some(a)):
@@ -227,8 +230,8 @@ export namespace NFT implements TZIP12Interface.FA2{
          };
       return (Set.mem(op.token_id, authorized) || op.owner == op.operator)
    };
-   @view
-   const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData => {
+
+   export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
       return match(Big_map.find_opt(p, s.token_metadata)) {
          when (Some(data)):
             data
@@ -236,4 +239,44 @@ export namespace NFT implements TZIP12Interface.FA2{
             failwith(Errors.undefined_token)
       }
    }
+}
+
+export namespace NFT implements TZIP12Interface.FA2 {
+  export type ledger = NFTExtendable.ledger;
+  export type operator = NFTExtendable.operator;
+  export type operators = NFTExtendable.operators;
+  export type storage = NFTExtendable.storage<unit>;
+  type ret = [list<operation>, storage];
+
+  @entry
+  const transfer = (t: TZIP12.transfer, s: storage): ret =>
+    NFTExtendable.transfer(t, s)
+
+  @entry
+  const balance_of = (b: TZIP12.balance_of, s: storage): ret =>
+    NFTExtendable.balance_of(b, s)
+
+  @entry
+  const update_operators = (updates: TZIP12.update_operators, s: storage): ret =>
+    NFTExtendable.update_operators(updates, s)
+
+  @view
+  const get_balance = (p: [address, nat], s: storage): nat =>
+    NFTExtendable.get_balance(p, s)
+
+  @view
+  const total_supply = (token_id: nat, s: storage): nat =>
+    NFTExtendable.total_supply(token_id, s)
+
+  @view
+  const all_tokens = (_: unit, s: storage): set<nat> =>
+    NFTExtendable.all_tokens(unit, s)
+
+  @view
+  const is_operator = (op: TZIP12.operator, s: storage): bool =>
+    NFTExtendable.is_operator(op, s)
+
+  @view
+  const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData =>
+    NFTExtendable.token_metadata(p, s)
 }

--- a/ligo.json
+++ b/ligo.json
@@ -1,6 +1,6 @@
 {
   "name": "@ligo/fa",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "FA2 interface and types compliant with TZIP12. The library is also providing 3 Ligo contract implementations for nft, single asset & multi asset contracts",
   "directories": {
     "lib": "lib",

--- a/test/fa2/multi_asset.test.mligo
+++ b/test/fa2/multi_asset.test.mligo
@@ -81,6 +81,7 @@ let get_initial_storage (a, b, c : nat * nat * nat) =
     token_metadata = token_metadata;
     operators      = operators;
     metadata       = metadata;
+    extension      = ();
   } in
 
   initial_storage, owners, ops
@@ -124,7 +125,7 @@ let test_atomic_tansfer_success =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 2n, 8n), (owner2, 2n, 12n), (owner3, 3n, 10n)) in
   ()
@@ -143,7 +144,7 @@ let test_transfer_token_undefined =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -162,7 +163,7 @@ let test_atomic_transfer_failure_not_operator =
   in
   let () = Test.set_source op3 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -181,7 +182,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -202,7 +203,7 @@ let test_atomic_tansfer_success_zero_amount_and_self_transfer =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 1n, 10n), (owner2, 2n, 10n), (owner3, 3n, 10n)) in
   ()
@@ -219,7 +220,7 @@ let test_transfer_failure_transitive_operators =
   in
   let () = Test.set_source op3 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -240,7 +241,7 @@ let test_empty_transfer_and_balance_of =
   } : FA2_multi_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
@@ -264,7 +265,7 @@ let test_balance_of_token_undefines =
   } : FA2_multi_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
 
   match result with
@@ -292,7 +293,7 @@ let test_balance_of_requests_with_duplicates =
   } : FA2_multi_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
@@ -318,7 +319,7 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
     } : FA2_multi_asset.TZIP12.balance_of) in
 
     let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-    
+
     let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
     let callback_storage = Test.get_storage orig_callback.addr in
@@ -335,7 +336,7 @@ let test_update_operator_remove_operator_and_transfer =
   let _owner3= List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner1 in
   let _ = Test.transfer_exn orig.addr
@@ -366,7 +367,7 @@ let test_update_operator_add_operator_and_transfer =
   let _owner3= List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner1 in
   let _ = Test.transfer_exn orig.addr

--- a/test/fa2/multi_asset_jsligo.test.mligo
+++ b/test/fa2/multi_asset_jsligo.test.mligo
@@ -81,6 +81,7 @@ let get_initial_storage (a, b, c : nat * nat * nat) =
     token_metadata = token_metadata;
     operators      = operators;
     metadata       = metadata;
+    extension      = ();
   } in
 
   initial_storage, owners, ops
@@ -124,7 +125,7 @@ let test_atomic_tansfer_success =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 2n, 8n), (owner2, 2n, 12n), (owner3, 3n, 10n)) in
   ()
@@ -143,7 +144,7 @@ let test_transfer_token_undefined =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -162,7 +163,7 @@ let test_atomic_transfer_failure_not_operator =
   in
   let () = Test.set_source op3 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -181,7 +182,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -202,7 +203,7 @@ let test_atomic_tansfer_success_zero_amount_and_self_transfer =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 1n, 10n), (owner2, 2n, 10n), (owner3, 3n, 10n)) in
   ()
@@ -219,7 +220,7 @@ let test_transfer_failure_transitive_operators =
   in
   let () = Test.set_source op3 in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -240,7 +241,7 @@ let test_empty_transfer_and_balance_of =
   } : FA2_multi_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
@@ -264,7 +265,7 @@ let test_balance_of_token_undefines =
   } : FA2_multi_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
 
   match result with
@@ -292,7 +293,7 @@ let test_balance_of_requests_with_duplicates =
   } : FA2_multi_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
@@ -318,7 +319,7 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
     } : FA2_multi_asset.TZIP12.balance_of) in
 
     let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-    
+
     let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
     let callback_storage = Test.get_storage orig_callback.addr in
@@ -335,7 +336,7 @@ let test_update_operator_remove_operator_and_transfer =
   let _owner3= List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner1 in
   let _ = Test.transfer_exn orig.addr
@@ -366,7 +367,7 @@ let test_update_operator_add_operator_and_transfer =
   let _owner3= List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
   let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner1 in
   let _ = Test.transfer_exn orig.addr

--- a/test/fa2/single_asset.test.mligo
+++ b/test/fa2/single_asset.test.mligo
@@ -83,6 +83,7 @@ let get_initial_storage (a, b, c : nat * nat * nat) =
       metadata       = metadata;
       token_metadata = token_metadata;
       operators      = operators;
+      extension      = ();
   } in
 
   initial_storage, owners, ops
@@ -125,7 +126,7 @@ let test_atomic_tansfer_success =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 8n), (owner2, 7n), (owner3, 15n)) in
   ()
@@ -144,7 +145,7 @@ let test_atomic_transfer_failure_not_operator =
   in
   let () = Test.set_source op3 in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -165,7 +166,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -186,7 +187,7 @@ let test_atomic_tansfer_success_zero_amount_and_self_transfer =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 10n), (owner2, 10n), (owner3, 10n)) in
   ()
@@ -204,7 +205,7 @@ let test_transfer_failure_transitive_operators =
   in
   let () = Test.set_source op2 in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -224,7 +225,7 @@ let test_empty_transfer_and_balance_of =
   } : FA2_single_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
@@ -238,7 +239,7 @@ let test_balance_of_requests_with_duplicates =
   let _owner3= List_helper.nth_exn 2 owners in
   let _op1   = List_helper.nth_exn 0 operators in
   let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  
+
 
   let balance_of_requests = ({
     requests = ([
@@ -250,7 +251,7 @@ let test_balance_of_requests_with_duplicates =
   } : FA2_single_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
@@ -264,7 +265,7 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
   let _owner3= List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
   let orig_callback = Test.originate (contract_of Callback) ([] : nat list) 0tez in
-  
+
 
   let balance_of_requests = ({
     requests = ([
@@ -276,7 +277,7 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
   } : FA2_single_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
@@ -292,7 +293,7 @@ let test_update_operator_remove_operator_and_transfer =
   let owner3 = List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner1 in
   let _ = Test.transfer_exn orig.addr
@@ -324,7 +325,7 @@ let test_update_operator_add_operator_and_transfer =
   let owner3 = List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner1 in
   let _ = Test.transfer_exn orig.addr

--- a/test/fa2/single_asset_jsligo.test.mligo
+++ b/test/fa2/single_asset_jsligo.test.mligo
@@ -82,6 +82,7 @@ let get_initial_storage (a, b, c : nat * nat * nat) =
       metadata       = metadata;
       token_metadata = token_metadata;
       operators      = operators;
+      extension      = ();
   } in
 
   initial_storage, owners, ops
@@ -142,7 +143,7 @@ let test_atomic_transfer_failure_not_operator =
   in
   let () = Test.set_source op3 in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -163,7 +164,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -184,7 +185,7 @@ let test_atomic_tansfer_success_zero_amount_and_self_transfer =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 10n), (owner2, 10n), (owner3, 10n)) in
   ()
@@ -202,7 +203,7 @@ let test_transfer_failure_transitive_operators =
   in
   let () = Test.set_source op2 in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
     Success _ -> failwith "This test should fail"
@@ -223,7 +224,7 @@ let test_empty_transfer_and_balance_of =
   } : FA2_single_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
@@ -249,7 +250,7 @@ let test_balance_of_requests_with_duplicates =
   } : FA2_single_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
@@ -275,7 +276,7 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
   } : FA2_single_asset.TZIP12.balance_of) in
 
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
@@ -291,7 +292,7 @@ let test_update_operator_remove_operator_and_transfer =
   let owner3 = List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner1 in
   let _ = Test.transfer_exn orig.addr
@@ -323,7 +324,7 @@ let test_update_operator_add_operator_and_transfer =
   let owner3 = List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
   let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner1 in
   let _ = Test.transfer_exn orig.addr

--- a/test/helpers/nft_helpers.mligo
+++ b/test/helpers/nft_helpers.mligo
@@ -71,13 +71,14 @@ let get_initial_storage () =
 
 }|}]);
 ] in
-  
+
 
   let initial_storage : FA2_NFT.NFT.storage = {
     ledger         = ledger;
     token_metadata = token_metadata;
     operators      = operators;
     metadata       = metadata;
+    extension      = ();
   } in
 
   initial_storage, owners, ops


### PR DESCRIPTION
Previous PR: https://github.com/ligolang/contract-catalogue/pull/35

I haven't actually ran any test for gas, but this is as simple as it gets so what else could we do (besides maybe having the compiler remove unit record fields). Note that the Taquito code does not need to be changed, as the library adds the unit extension itself (example of contract deployed using this code: https://ghostnet.tzkt.io/KT1GEnEEEyQq64KKkA63UuXmCcSDa3R3pjoE/storage/). 

Don't merge just now as I might update it a bit, depending on some other things I want to change:
* The code in `examples/` seems incomplete, I'll add something in a different PR.
* I don't know if there's anything available to format Ligo code. Any advice? Lots of noise here from removing trailing whitespaces though.
* The interface isn't great, I'll expose more things in `lib/main.mligo`.
* Also lots of code duplication. I didn't change anything here but I will refactor some of it over subsequent PRs.