### PR TITLE
Extendable api: easier storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@grep -E '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
 	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-compile = $(ligo_compiler) compile contract $(project_root) -m $(1) ./lib/$(2) -o ./compiled/$(3) $(4) $(PROTOCOL_OPT)
+compile = $(ligo_compiler) compile contract $(project_root) ./lib/$(1) -o ./compiled/$(2) $(3) $(PROTOCOL_OPT)
 # ^ compile contract to michelson or micheline
 
 test = $(ligo_compiler) run test $(project_root) ./test/$(1) $(PROTOCOL_OPT)
@@ -21,12 +21,12 @@ test = $(ligo_compiler) run test $(project_root) ./test/$(1) $(PROTOCOL_OPT)
 compile: ## compile contracts
 	@if [ ! -d ./compiled ]; then mkdir -p ./compiled/fa2/nft && mkdir -p ./compiled/fa2/asset ; fi
 	@echo "Compiling contracts..."
-	@$(call compile,NFT,fa2/nft/nft.impl.mligo,fa2/nft/nft.impl.mligo.tz)
-	@$(call compile,NFT,fa2/nft/nft.impl.mligo,fa2/nft/nft.impl.mligo.json,--michelson-format json)
-	@$(call compile,SingleAsset,fa2/asset/single_asset.impl.mligo,fa2/asset/single_asset.impl.mligo.tz)
-	@$(call compile,SingleAsset,fa2/asset/single_asset.impl.mligo,fa2/asset/single_asset.impl.mligo.json,--michelson-format json)
-	@$(call compile,MultiAsset,fa2/asset/multi_asset.impl.mligo,fa2/asset/multi_asset.impl.mligo.tz)
-	@$(call compile,MultiAsset,fa2/asset/multi_asset.impl.mligo,fa2/asset/multi_asset.impl.mligo.json,--michelson-format json)
+	@$(call compile,fa2/nft/nft.impl.mligo,fa2/nft/nft.impl.mligo.tz)
+	@$(call compile,fa2/nft/nft.impl.mligo,fa2/nft/nft.impl.mligo.json,--michelson-format json)
+	@$(call compile,fa2/asset/single_asset.impl.mligo,fa2/asset/single_asset.impl.mligo.tz)
+	@$(call compile,fa2/asset/single_asset.impl.mligo,fa2/asset/single_asset.impl.mligo.json,--michelson-format json)
+	@$(call compile,fa2/asset/multi_asset.impl.mligo,fa2/asset/multi_asset.impl.mligo.tz)
+	@$(call compile,fa2/asset/multi_asset.impl.mligo,fa2/asset/multi_asset.impl.mligo.json,--michelson-format json)
 	@echo "Compiled contracts!"
 clean: ## clean up
 	@rm -rf compiled

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ To extend the storage, define the type of the extension and refer to the origina
 such:
 
 ```ocaml
+#import "@ligo/fa/lib/main.mligo" "FA2"
+
 module NFT = FA2.NFTExtendable
 
 type extension = {

--- a/README.md
+++ b/README.md
@@ -26,70 +26,75 @@ make compile
 make deploy
 ```
 
-## Extend the implementation
+## Extend an implementation
 
-If you want to build a dapp that is more than just a FA2 contract, like an NFT marketplace, you can extend the base code
+If you need additional features in your contract, you can use the extendable version. An example is
+available in the file `examples/mintable.mligo`. Using the extension mechanism, it adds an admin
+address to the storage, as well as a `mint` entrypoint to mint owner-less NFTs. Only the admin can
+call this entrypoint.
 
 Install the library and create a new file
 
 ```bash
 ligo install @ligo/fa
-touch marketplace.jsligo
+touch mintable.mligo
 ```
 
-Edit the file to add an additional field `administrators`
+To extend the storage, define the type of the extension and refer to the original storage type as
+such:
 
-```ligolang
-#import "@ligo/fa/lib/fa2/nft/nft.impl.jsligo" "Contract"
+```ocaml
+module NFT = FA2.NFTExtendable
 
-export type storage = {
-    administrators: set<address>,
-    ledger: Contract.NFT.ledger,
-    metadata: Contract.TZIP16.metadata,
-    token_metadata: Contract.TZIP12.tokenMetadata,
-    operators: Contract.NFT.operators,
-    extension: unit
-};
+type extension = {
+  admin: address
+}
 
-type ret = [list<operation>, storage];
-
-import Contract = Contract.NFT
-
+type storage = extension NFT.storage
+type ret = operation list * storage
 ```
 
-Importing the library allows you to add TZIP types to your custom storage.
+Importing the library allows you to refer to the TZIP12 operations signatures and make it easier to
+redefine all the entrypoints and views that are required:
 
-Add the TZIP12 default entrypoints, calling the functions of the library and mapping it to your custom storage. For instance, to reimplement the `transfer` entrypoint, do:
+```ocaml
+(* Standard FA2 interface, copied from the source *)
 
-```ligolang
-@entry
-const transfer = (p: Contract.TZIP12.transfer, s: storage): ret => {
-    const ret2: [list<operation>, Contract.NFT.storage] =
-        Contract.NFT.transfer(
-            p,
-            {
-                ledger: s.ledger,
-                metadata: s.metadata,
-                token_metadata: s.token_metadata,
-                operators: s.operators,
-                extension: unit
-            }
-        );
-    return [
-        ret2[0],
-        {
-            ...s,
-            ledger: ret2[1].ledger,
-            metadata: ret2[1].metadata,
-            token_metadata: ret2[1].token_metadata,
-            operators: ret2[1].operators,
-            extension: unit
-        }
-    ]
-};
+[@entry]
+let transfer (t: NFT.TZIP12.transfer) (s: storage) : ret =
+  NFT.transfer t s
+
+[@entry]
+let balance_of (b: NFT.TZIP12.balance_of) (s: storage) : ret =
+  NFT.balance_of b s
+
+(* Etc. *)
 ```
 
-See the `examples/marketplace.jsligo` file for a complete example.
+To make it easier to define new entrypoints, some functions are available in the library, and you
+can also use the `storage` fields directly:
+
+```ocaml
+(* Extension *)
+
+type mint = {
+   owner    : address;
+   token_id : nat;
+}
+
+[@entry]
+let mint (mint : mint) (s : storage): ret =
+  let sender = Tezos.get_sender () in
+  let () = assert (sender = s.extension.admin) in
+  let () = NFT.Assertions.assert_token_exist s.token_metadata mint.token_id in
+  (* Check that nobody owns the token already *)
+  let () = assert (Option.is_none (Big_map.find_opt mint.token_id s.ledger)) in
+  let s = NFT.set_balance s mint.owner mint.token_id in
+  [], s
+```
+
+Note that this version requires the minted NFTs to be already defined in the `token_metadata` big
+map. However, you can also change the `mint` entrypoint to create new tokens dynamically.
 
 ## Implement the interface differently
 

--- a/examples/marketplace.jsligo
+++ b/examples/marketplace.jsligo
@@ -58,7 +58,7 @@ const balance_of = (p: Contract.TZIP12.balance_of, s: storage): ret => {
             ledger: ret2[1].ledger,
             metadata: ret2[1].metadata,
             token_metadata: ret2[1].token_metadata,
-            operators: ret2[1].operators;
+            operators: ret2[1].operators,
         }
     ]
 };

--- a/examples/marketplace.jsligo
+++ b/examples/marketplace.jsligo
@@ -7,26 +7,24 @@ import Contract = FA2.NFT
 
 export type storage = {
     administrators: set<address>,
-    ledger: Contract.NFT.ledger,
+    ledger: Contract.ledger,
     metadata: Contract.TZIP16.metadata,
     token_metadata: Contract.TZIP12.tokenMetadata,
-    operators: Contract.NFT.operators,
-    extension: unit
+    operators: Contract.operators,
 };
 
 type ret = [list<operation>, storage];
 
 @entry
 const transfer = (p: Contract.TZIP12.transfer, s: storage): ret => {
-    const ret2: [list<operation>, Contract.NFT.storage] =
-        Contract.NFT.transfer(
+    const ret2: [list<operation>, Contract.storage] =
+        Contract.transfer(
             p,
             {
                 ledger: s.ledger,
                 metadata: s.metadata,
                 token_metadata: s.token_metadata,
                 operators: s.operators,
-                extension: unit
             }
         );
     return [
@@ -37,22 +35,20 @@ const transfer = (p: Contract.TZIP12.transfer, s: storage): ret => {
             metadata: ret2[1].metadata,
             token_metadata: ret2[1].token_metadata,
             operators: ret2[1].operators,
-            extension: unit
         }
     ]
 };
 
 @entry
 const balance_of = (p: Contract.TZIP12.balance_of, s: storage): ret => {
-    const ret2: [list<operation>, Contract.NFT.storage] =
-        Contract.NFT.balance_of(
+    const ret2: [list<operation>, Contract.storage] =
+        Contract.balance_of(
             p,
             {
                 ledger: s.ledger,
                 metadata: s.metadata,
                 token_metadata: s.token_metadata,
                 operators: s.operators,
-                extension: unit
             }
         );
     return [
@@ -63,22 +59,20 @@ const balance_of = (p: Contract.TZIP12.balance_of, s: storage): ret => {
             metadata: ret2[1].metadata,
             token_metadata: ret2[1].token_metadata,
             operators: ret2[1].operators;
-            extension: unit
         }
     ]
 };
 
 @entry
 const update_operators = (p: Contract.TZIP12.update_operators, s: storage): ret => {
-    const ret2: [list<operation>, Contract.NFT.storage] =
-        Contract.NFT.update_operators(
+    const ret2: [list<operation>, Contract.storage] =
+        Contract.update_operators(
             p,
             {
                 ledger: s.ledger,
                 metadata: s.metadata,
                 token_metadata: s.token_metadata,
                 operators: s.operators,
-                extension: unit
             }
         );
     return [
@@ -89,7 +83,6 @@ const update_operators = (p: Contract.TZIP12.update_operators, s: storage): ret 
             metadata: ret2[1].metadata,
             token_metadata: ret2[1].token_metadata,
             operators: ret2[1].operators,
-            extension: unit
         }
     ]
 };

--- a/examples/mintable.mligo
+++ b/examples/mintable.mligo
@@ -20,9 +20,9 @@ type mint = {
 let mint (mint : mint) (s : storage): ret =
   let sender = Tezos.get_sender () in
   let () = assert (sender = s.extension.admin) in
-  (* TODO ?
-  let () = FA2.Storage.assert_token_exist  s token_id in
-  *)
+  let () = NFT.Assertions.assert_token_exist s.token_metadata mint.token_id in
+  (* Check that nobody owns the token already *)
+  let () = assert (Option.is_none (Big_map.find_opt mint.token_id s.ledger)) in
   let s = NFT.set_balance s mint.owner mint.token_id in
   [], s
 
@@ -44,7 +44,6 @@ let update_operators (u: NFT.TZIP12.update_operators) (s: storage) : ret =
 let get_balance (p : (address * nat)) (s : storage) : nat =
   NFT.get_balance p s
 
-(* FIXME Not sure why we are implementing the two following views *)
 [@view]
 let total_supply (token_id : nat) (s : storage) : nat =
   NFT.total_supply token_id s

--- a/examples/myTzip12NFTImplementation.jsligo
+++ b/examples/myTzip12NFTImplementation.jsligo
@@ -13,11 +13,11 @@ export namespace NFT implements TZIP12Interface.FA2{
     type operator = address;
     export type operators = big_map<[address, operator], set<nat>>;
     export type storage = {
+        extension: unit,
         ledger: ledger,
         operators: operators,
         token_metadata: TZIP12.tokenMetadata,
         metadata: TZIP16.metadata,
-        extension: unit
     };
     type ret = [list<operation>, storage];
     @entry

--- a/examples/with_admin.mligo
+++ b/examples/with_admin.mligo
@@ -1,0 +1,63 @@
+#import "../lib/main.mligo" "FA2"
+
+module NFT = FA2.NFTExtendable
+
+type extension = {
+  admin: address
+}
+
+type storage = extension NFT.storage
+type ret = operation list * storage
+
+(* Extension *)
+
+type mint = {
+   owner    : address;
+   token_id : nat;
+}
+
+[@entry]
+let mint (mint : mint) (s : storage): ret =
+  let sender = Tezos.get_sender () in
+  let () = assert (sender = s.extension.admin) in
+  (* TODO ?
+  let () = FA2.Storage.assert_token_exist  s token_id in
+  *)
+  let s = NFT.set_balance s mint.owner mint.token_id in
+  [], s
+
+(* Standard FA2 interface, copied from the source *)
+
+[@entry]
+let transfer (t: NFT.TZIP12.transfer) (s: storage) : ret =
+  NFT.transfer t s
+
+[@entry]
+let balance_of (b: NFT.TZIP12.balance_of) (s: storage) : ret =
+  NFT.balance_of b s
+
+[@entry]
+let update_operators (u: NFT.TZIP12.update_operators) (s: storage) : ret =
+  NFT.update_operators  u s
+
+[@view]
+let get_balance (p : (address * nat)) (s : storage) : nat =
+  NFT.get_balance p s
+
+(* FIXME Not sure why we are implementing the two following views *)
+[@view]
+let total_supply (token_id : nat) (s : storage) : nat =
+  NFT.total_supply token_id s
+
+[@view]
+let all_tokens (_ : unit) (s : storage) : nat set =
+  NFT.all_tokens () s
+
+[@view]
+let is_operator (op : NFT.TZIP12.operator) (s : storage) : bool =
+  NFT.is_operator op s
+
+[@view]
+let token_metadata (p : nat) (s : storage) : NFT.TZIP12.tokenMetadataData =
+  NFT.token_metadata p s
+

--- a/lib/fa2/asset/extendable_multi_asset.impl.jsligo
+++ b/lib/fa2/asset/extendable_multi_asset.impl.jsligo
@@ -1,0 +1,230 @@
+#import "../common/assertions.jsligo" "Assertions"
+#import "../common/errors.mligo" "Errors"
+#import "../common/tzip12.datatypes.jsligo" "TZIP12"
+#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+
+ export type ledger = big_map<[address, nat], nat>;
+ export type operator = address;
+ export type operators = big_map<[address, operator], set<nat>>;
+ export type storage<T> = {
+    ledger: ledger,
+    operators: operators,
+    token_metadata: TZIP12.tokenMetadata,
+    metadata: TZIP16.metadata,
+    extension: T
+ };
+ type ret<T> = [list<operation>, storage<T>];
+ //operators
+
+ export const assert_authorisation = (
+    [operators, from_, token_id]: [operators, address, nat]
+ ): unit => {
+    const sender_ = (Tezos.get_sender());
+    if (sender_ != from_) {
+       const authorized =
+          match((Big_map.find_opt([from_, sender_], operators))) {
+             when (Some(a)):
+                a
+             when (None()):
+                Set.empty
+          };
+       if (! (Set.mem(token_id, authorized))) {
+          return failwith(Errors.not_operator)
+       }
+    }
+ };
+ export const add_operator = (
+    [operators, owner, operator, token_id]: [
+       operators,
+       address,
+       operator,
+       nat
+    ]
+ ): operators => {
+    if (owner == operator) {
+       return operators
+    } // assert_authorisation always allow the owner so this case is not relevant
+     else {
+       Assertions.assert_update_permission(owner);
+       let auth_tokens =
+          match(Big_map.find_opt([owner, operator], operators)) {
+             when (Some(ts)):
+                ts
+             when (None()):
+                Set.empty
+          };
+       auth_tokens = Set.add(token_id, auth_tokens);
+       return Big_map.update([owner, operator], Some(auth_tokens), operators)
+    }
+ };
+ export const remove_operator = (
+    [operators, owner, operator, token_id]: [
+       operators,
+       address,
+       operator,
+       nat
+    ]
+ ): operators => {
+    if (owner == operator) {
+       return operators
+    } // assert_authorisation always allow the owner so this case is not relevant
+     else {
+       Assertions.assert_update_permission(owner);
+       const auth_tokens: option<set<nat>> =
+          match(Big_map.find_opt([owner, operator], operators)) {
+             when (Some(toks)):
+                do {
+                   const ts = Set.remove(token_id, toks);
+                   if (Set.cardinal(ts) == 0n) {
+                      return None()
+                   } else {
+                      return Some(ts)
+                   }
+                }
+             when (None()):
+                None()
+          };
+       return Big_map.update([owner, operator], auth_tokens, operators)
+    }
+ }
+ // ledger
+
+ export const get_for_user = (
+    [ledger, owner, token_id]: [ledger, address, nat]
+ ): nat =>
+    match((Big_map.find_opt([owner, token_id], ledger))) {
+       when (Some(a)):
+          a
+       when (None()):
+          0 as nat
+    };
+ const set_for_user = (
+    [ledger, owner, token_id, amount_]: [ledger, address, nat, nat]
+ ): ledger =>
+    Big_map.update([owner, token_id], Some(amount_), ledger);
+ export const decrease_token_amount_for_user = (
+    [ledger, from_, token_id, amount_]: [ledger, address, nat, nat]
+ ): ledger => {
+    let balance_ = get_for_user([ledger, from_, token_id]);
+    assert_with_error((balance_ >= amount_), Errors.ins_balance);
+    balance_ = abs(balance_ - amount_);
+    return set_for_user([ledger, from_, token_id, balance_])
+ };
+ export const increase_token_amount_for_user = (
+    [ledger, to_, token_id, amount_]: [ledger, address, nat, nat]
+ ): ledger => {
+    let balance_ = get_for_user([ledger, to_, token_id]);
+    balance_ = balance_ + amount_;
+    return set_for_user([ledger, to_, token_id, balance_])
+ }
+ // storage
+
+ export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
+    ({ ...s, ledger: ledger });
+ export const get_operators = <T>(s: storage<T>): operators => s.operators;
+ export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
+    ({ ...s, operators: operators })
+
+ export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
+    const process_atomic_transfer = (from_: address) =>
+       ([l, t]: [ledger, TZIP12.atomic_trans]): ledger => {
+          const { to_, token_id, amount } = t;
+          Assertions.assert_token_exist(s.token_metadata, token_id);
+          assert_authorisation([s.operators, from_, token_id]);
+          let ledger =
+             decrease_token_amount_for_user([l, from_, token_id, amount]);
+          ledger
+          = increase_token_amount_for_user([ledger, to_, token_id, amount]);
+          return ledger
+       };
+    const process_single_transfer = ([l, t]: [ledger, TZIP12.transfer_from]): ledger => {
+       const { from_, txs } = t;
+       const ledger = List.fold_left(process_atomic_transfer(from_), l, txs);
+       return ledger
+    };
+    const ledger = List.fold_left(process_single_transfer, s.ledger, t);
+    return [list([]), set_ledger([s, ledger])]
+ };
+
+ export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
+    const { requests, callback } = b;
+    const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
+       const { owner, token_id } = request;
+       Assertions.assert_token_exist(s.token_metadata, token_id);
+       const balance_ = get_for_user([s.ledger, owner, token_id]);
+       return ({ request: request, balance: balance_ })
+    };
+    const callback_param = List.map(get_balance_info, requests);
+    const operation =
+       Tezos.transaction(Main(callback_param), 0mutez, callback);
+    return [list([operation]), s]
+ };
+
+ export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
+    const update_operator = (
+       [operators, update]: [operators, TZIP12.unit_update]
+    ): operators =>
+       match(update) {
+          when (Add_operator(operator)):
+             add_operator(
+                [
+                   operators,
+                   operator.owner,
+                   operator.operator,
+                   operator.token_id
+                ]
+             )
+          when (Remove_operator(operator)):
+             remove_operator(
+                [
+                   operators,
+                   operator.owner,
+                   operator.operator,
+                   operator.token_id
+                ]
+             )
+       };
+    let operators = get_operators(s);
+    operators = List.fold_left(update_operator, operators, updates);
+    const store = set_operators([s, operators]);
+    return [list([]), store]
+ };
+
+ export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
+    const [owner, token_id] = p;
+    Assertions.assert_token_exist(s.token_metadata, token_id);
+    return match(Big_map.find_opt([owner, token_id], s.ledger)) {
+       when (None()):
+          0n
+       when (Some(n)):
+          n
+    }
+ };
+
+ export const total_supply = <T>(_token_id: nat, _s: storage<T>): nat =>
+    failwith(Errors.not_available);
+
+ export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
+    failwith(Errors.not_available);
+
+ export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
+    const authorized =
+       match(Big_map.find_opt([op.owner, op.operator], s.operators)) {
+          when (Some(opSet)):
+             opSet
+          when (None()):
+             Set.empty
+       };
+    return (Set.size(authorized) > 0n || op.owner == op.operator)
+ };
+
+ export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
+    return match(Big_map.find_opt(p, s.token_metadata)) {
+       when (Some(data)):
+          data
+       when (None()):
+          failwith(Errors.undefined_token)
+    }
+ };
+
+

--- a/lib/fa2/asset/extendable_multi_asset.impl.mligo
+++ b/lib/fa2/asset/extendable_multi_asset.impl.mligo
@@ -1,0 +1,223 @@
+#import "../common/assertions.jsligo" "Assertions"
+#import "../common/errors.mligo" "Errors"
+#import "../common/tzip12.datatypes.jsligo" "TZIP12"
+#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+
+type ledger = ((address * nat), nat) big_map
+
+type operator = address
+
+type operators = ((address * operator), nat set) big_map
+
+type 'a storage =
+  {
+   ledger : ledger;
+   operators : operators;
+   token_metadata : TZIP12.tokenMetadata;
+   metadata : TZIP16.metadata;
+   extension : 'a
+  }
+
+type 'a ret = operation list * 'a storage
+
+// Operators
+
+let assert_authorisation
+  (operators : operators)
+  (from_ : address)
+  (token_id : nat)
+: unit =
+  let sender_ = (Tezos.get_sender ()) in
+  if (sender_ = from_)
+  then ()
+  else
+    let authorized =
+      match Big_map.find_opt (from_, sender_) operators with
+        Some (a) -> a
+      | None -> Set.empty in
+    if Set.mem token_id authorized then () else failwith Errors.not_operator
+
+let add_operator
+  (operators : operators)
+  (owner : address)
+  (operator : operator)
+  (token_id : nat)
+: operators =
+  if owner = operator
+  then operators
+  (* assert_authorisation always allow the owner so this case is not relevant *)
+
+  else
+    let () = Assertions.assert_update_permission owner in
+    let auth_tokens =
+      match Big_map.find_opt (owner, operator) operators with
+        Some (ts) -> ts
+      | None -> Set.empty in
+    let auth_tokens = Set.add token_id auth_tokens in
+    Big_map.update (owner, operator) (Some auth_tokens) operators
+
+let remove_operator
+  (operators : operators)
+  (owner : address)
+  (operator : operator)
+  (token_id : nat)
+: operators =
+  if owner = operator
+  then operators
+  (* assert_authorisation always allow the owner so this case is not relevant *)
+
+  else
+    let () = Assertions.assert_update_permission owner in
+    let auth_tokens =
+      match Big_map.find_opt (owner, operator) operators with
+        None -> None
+      | Some (ts) ->
+          let ts = Set.remove token_id ts in
+          if (Set.size ts = 0n) then None else Some (ts) in
+    Big_map.update (owner, operator) auth_tokens operators
+
+// Ledger
+
+let get_for_user (ledger : ledger) (owner : address) (token_id : nat) : nat =
+  match Big_map.find_opt (owner, token_id) ledger with
+    Some (a) -> a
+  | None -> 0n
+
+let set_for_user
+  (ledger : ledger)
+  (owner : address)
+  (token_id : nat)
+  (amount_ : nat)
+: ledger = Big_map.update (owner, token_id) (Some amount_) ledger
+
+let decrease_token_amount_for_user
+  (ledger : ledger)
+  (from_ : address)
+  (token_id : nat)
+  (amount_ : nat)
+: ledger =
+  let balance_ = get_for_user ledger from_ token_id in
+  let () = assert_with_error (balance_ >= amount_) Errors.ins_balance in
+  let balance_ = abs (balance_ - amount_) in
+  let ledger = set_for_user ledger from_ token_id balance_ in
+  ledger
+
+let increase_token_amount_for_user
+  (ledger : ledger)
+  (to_ : address)
+  (token_id : nat)
+  (amount_ : nat)
+: ledger =
+  let balance_ = get_for_user ledger to_ token_id in
+  let balance_ = balance_ + amount_ in
+  let ledger = set_for_user ledger to_ token_id balance_ in
+  ledger
+
+// Storage
+
+let assert_token_exist (type a) (s : a storage) (token_id : nat) : unit =
+  let _ =
+    Option.unopt_with_error
+      (Big_map.find_opt token_id s.token_metadata)
+      Errors.undefined_token in
+  ()
+
+let set_ledger (type a) (s : a storage) (ledger : ledger) = {s with ledger = ledger}
+
+let get_operators (type a) (s : a storage) = s.operators
+
+let set_operators (type a) (s : a storage) (operators : operators) =
+  {s with operators = operators}
+
+let transfer (type a) (t : TZIP12.transfer) (s : a storage) : a ret =
+  (* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se *)
+
+  let process_atomic_transfer
+    (from_ : address)
+    (ledger, t : ledger * TZIP12.atomic_trans) =
+    let {
+     to_;
+     token_id;
+     amount = amount_
+    } = t in
+    let () = assert_token_exist s token_id in
+    let () = assert_authorisation s.operators from_ token_id in
+    let ledger = decrease_token_amount_for_user ledger from_ token_id amount_ in
+    let ledger = increase_token_amount_for_user ledger to_ token_id amount_ in
+    ledger in
+  let process_single_transfer (ledger, t : ledger * TZIP12.transfer_from) =
+    let {
+     from_;
+     txs
+    } = t in
+    let ledger = List.fold_left (process_atomic_transfer from_) ledger txs in
+    ledger in
+  let ledger = List.fold_left process_single_transfer s.ledger t in
+  ([] : operation list), set_ledger s ledger
+
+let balance_of (type a) (b : TZIP12.balance_of) (s : a storage) : a ret =
+  let {
+   requests;
+   callback
+  } = b in
+  let get_balance_info (request : TZIP12.request) : TZIP12.callback =
+    let {
+     owner;
+     token_id
+    } = request in
+    let () = assert_token_exist s token_id in
+    let balance_ = get_for_user s.ledger owner token_id in
+    {
+     request = request;
+     balance = balance_
+    } in
+  let callback_param = List.map get_balance_info requests in
+  let operation = Tezos.transaction (Main callback_param) 0mutez callback in
+  ([operation] : operation list), s
+
+let update_operators (type a) (updates : TZIP12.update_operators) (s : a storage) : a ret =
+  let update_operator (operators, update : operators * TZIP12.unit_update) =
+    match update with
+      Add_operator
+        {
+         owner = owner;
+         operator = operator;
+         token_id = token_id
+        } -> add_operator operators owner operator token_id
+    | Remove_operator
+        {
+         owner = owner;
+         operator = operator;
+         token_id = token_id
+        } -> remove_operator operators owner operator token_id in
+  let operators = get_operators s in
+  let operators = List.fold_left update_operator operators updates in
+  let s = set_operators s operators in
+  ([] : operation list), s
+
+let get_balance (type a) (p : (address * nat)) (s : a storage) : nat =
+  let (owner, token_id) = p in
+  let () = assert_token_exist s token_id in
+  match Big_map.find_opt (owner, token_id) s.ledger with
+    None -> 0n
+  | Some (n) -> n
+
+let total_supply (type a) (_token_id : nat) (_s : a storage) : nat =
+  failwith Errors.not_available
+
+let all_tokens (type a) (_ : unit) (_s : a storage) : nat set =
+  failwith Errors.not_available
+
+let is_operator (type a) (op : TZIP12.operator) (s : a storage) : bool =
+  let authorized =
+    match Big_map.find_opt (op.owner, op.operator) s.operators with
+      Some (opSet) -> opSet
+    | None -> Set.empty in
+  Set.size authorized > 0n || op.owner = op.operator
+
+let token_metadata (type a) (p : nat) (s : a storage) : TZIP12.tokenMetadataData =
+  match Big_map.find_opt p s.token_metadata with
+    Some (data) -> data
+  | None () -> failwith Errors.undefined_token
+
+

--- a/lib/fa2/asset/extendable_single_asset.impl.jsligo
+++ b/lib/fa2/asset/extendable_single_asset.impl.jsligo
@@ -1,0 +1,221 @@
+#import "../common/assertions.jsligo" "Assertions"
+#import "../common/errors.mligo" "Errors"
+#import "../common/tzip12.datatypes.jsligo" "TZIP12"
+#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+
+ export type ledger = big_map<address, nat>;
+ export type operator = address;
+ export type operators = big_map<address, set<operator>>;
+ export type storage<T> = {
+    ledger: ledger,
+    operators: operators,
+    token_metadata: TZIP12.tokenMetadata,
+    metadata: TZIP16.metadata,
+    extension: T
+ };
+ type ret<T> = [list<operation>, storage<T>];
+ // operators
+
+ export const assert_authorisation = (operators: operators, from_: address): unit => {
+    const sender_ = Tezos.get_sender();
+    if (sender_ == from_) return unit else {
+       const authorized =
+          match(Big_map.find_opt(from_, operators)) {
+             when (Some(a)):
+                a
+             when (None()):
+                Set.empty
+          };
+       if (Set.mem(sender_, authorized)) return unit else failwith(
+          Errors.not_operator
+       )
+    }
+ };
+ export const add_operator = (
+    operators: operators,
+    owner: address,
+    operator: operator
+ ): operators => {
+    if (owner == operator) return operators else {
+       const _ = Assertions.assert_update_permission(owner);
+       let auths =
+          match(Big_map.find_opt(owner, operators)) {
+             when (Some(os)):
+                os
+             when (None()):
+                Set.empty
+          };
+       auths = Set.add(operator, auths);
+       return Big_map.update(owner, Some(auths), operators)
+    }
+ };
+ export const remove_operator = (
+    operators: operators,
+    owner: address,
+    operator: operator
+ ): operators => {
+    if (owner == operator) return operators else {
+       const _ = Assertions.assert_update_permission(owner);
+       const auths =
+          match(Big_map.find_opt(owner, operators)) {
+             when (None()):
+                None()
+             when (Some(ops)):
+                do {
+                   let os = Set.remove(operator, ops);
+                   if (Set.size(os) == 0n) return None() else return Some(os)
+                }
+          };
+       return Big_map.update(owner, auths, operators)
+    }
+ }
+ // ledger
+
+ export const get_for_user = (ledger: ledger, owner: address): nat =>
+    match(Big_map.find_opt(owner, ledger)) {
+       when (Some(tokens)):
+          tokens
+       when (None()):
+          0 as nat
+    };
+ const update_for_user = (ledger: ledger, owner: address, amount_: nat): ledger =>
+    Big_map.update(owner, Some(amount_), ledger);
+ export const decrease_token_amount_for_user = (
+    ledger: ledger,
+    from_: address,
+    amount_: nat
+ ): ledger => {
+    let tokens = get_for_user(ledger, from_);
+    const _ = assert_with_error(tokens >= amount_, Errors.ins_balance);
+    tokens = abs(tokens - amount_);
+    return update_for_user(ledger, from_, tokens)
+ };
+ export const increase_token_amount_for_user = (
+    ledger: ledger,
+    to_: address,
+    amount_: nat
+ ): ledger => {
+    let tokens = get_for_user(ledger, to_);
+    tokens = tokens + amount_;
+    return update_for_user(ledger, to_, tokens)
+ }
+ // Storage
+
+ export const get_amount_for_owner = <T>(s: storage<T>, owner: address) =>
+    get_for_user(s.ledger, owner);
+ export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
+    ({ ...s, ledger: ledger });
+ export const get_operators = <T>(s: storage<T>): operators => s.operators;
+ export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
+    ({ ...s, operators: operators })
+
+  export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
+    /* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se */
+
+    const process_atomic_transfer = (from_: address) =>
+       ([ledger, t]: [ledger, TZIP12.atomic_trans]): ledger => {
+          const { to_, token_id, amount } = t;
+          ignore(token_id);
+          const _ = assert_authorisation(s.operators, from_);
+          let l = decrease_token_amount_for_user(ledger, from_, amount);
+          return increase_token_amount_for_user(l, to_, amount)
+       };
+    const process_single_transfer = (
+       [ledger, t]: [ledger, TZIP12.transfer_from]
+    ): ledger => {
+       const { from_, txs } = t;
+       return List.fold_left(process_atomic_transfer(from_), ledger, txs)
+    };
+    const ledger = List.fold_left(process_single_transfer, s.ledger, t);
+    const store = set_ledger([s, ledger]);
+    return [list([]), store]
+ };
+ /** balance_of entrypoint
+*/
+
+ export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
+    const { requests, callback } = b;
+    const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
+       const { owner, token_id } = request;
+       ignore(token_id);
+       const balance_ = get_amount_for_owner(s, owner);
+       return { request: request, balance: balance_ }
+    };
+    const callback_param = List.map(get_balance_info, requests);
+    const operation =
+       Tezos.transaction(Main(callback_param), 0mutez, callback);
+    return [list([operation]), s]
+ };
+ /**
+Add or Remove token operators for the specified token owners and token IDs.
+
+
+The entrypoint accepts a list of update_operator commands. If two different
+commands in the list add and remove an operator for the same token owner and
+token ID, the last command in the list MUST take effect.
+
+
+It is possible to update operators for a token owner that does not hold any token
+balances yet.
+
+
+Operator relation is not transitive. If C is an operator of B and if B is an
+operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
+
+
+*/
+
+ export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
+    const update_operator = (
+       [operators, update]: [operators, TZIP12.unit_update]
+    ): operators =>
+       match(update) {
+          when (Add_operator(operator)):
+             add_operator(operators, operator.owner, operator.operator)
+          when (Remove_operator(operator)):
+             remove_operator(operators, operator.owner, operator.operator)
+       };
+    const operators =
+       List.fold_left(update_operator, get_operators(s), updates);
+    const store = set_operators([s, operators]);
+    return [list([]), store]
+ };
+
+ export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
+    const [owner, token_id] = p;
+    Assertions.assert_token_exist(s.token_metadata, token_id);
+    return match(Big_map.find_opt(owner, s.ledger)) {
+       when (None()):
+          0n
+       when (Some(n)):
+          n
+    }
+ };
+
+ export const total_supply = <T>(_token_id: nat, _s: storage<T>): nat =>
+    failwith(Errors.not_available);
+
+ export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
+    failwith(Errors.not_available);
+
+ export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
+    const authorized =
+       match(Big_map.find_opt(op.owner, s.operators)) {
+          when (Some(opSet)):
+             opSet
+          when (None()):
+             Set.empty
+       };
+    return (Set.mem(op.operator, authorized) || op.owner == op.operator)
+ };
+
+ export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
+    return match(Big_map.find_opt(p, s.token_metadata)) {
+       when (Some(data)):
+          data
+       when (None()):
+          failwith(Errors.undefined_token)
+    }
+ };
+
+

--- a/lib/fa2/asset/extendable_single_asset.impl.mligo
+++ b/lib/fa2/asset/extendable_single_asset.impl.mligo
@@ -1,0 +1,226 @@
+#import "../common/assertions.jsligo" "Assertions"
+#import "../common/errors.mligo" "Errors"
+#import "../common/tzip12.datatypes.jsligo" "TZIP12"
+#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+
+
+type ledger = (address, nat) big_map
+
+type operator = address
+
+type operators = (address, operator set) big_map
+
+type 'a storage = {
+   ledger : ledger;
+   operators : operators;
+   token_metadata : TZIP12.tokenMetadata;
+   metadata : TZIP16.metadata;
+   extension: 'a
+  }
+
+type 'a ret = operation list * 'a storage
+
+// Operators
+
+let assert_authorisation (operators : operators) (from_ : address) : unit =
+  let sender_ = (Tezos.get_sender ()) in
+  if (sender_ = from_)
+  then ()
+  else
+    let authorized =
+      match Big_map.find_opt from_ operators with
+        Some (a) -> a
+      | None -> Set.empty in
+    if Set.mem sender_ authorized then () else failwith Errors.not_operator
+
+let add_operator
+  (operators : operators)
+  (owner : address)
+  (operator : operator)
+: operators =
+  if owner = operator
+  then operators
+  (* assert_authorisation always allow the owner so this case is not relevant *)
+
+  else
+    let () = Assertions.assert_update_permission owner in
+    let auths =
+      match Big_map.find_opt owner operators with
+        Some (os) -> os
+      | None -> Set.empty in
+    let auths = Set.add operator auths in
+    Big_map.update owner (Some auths) operators
+
+let remove_operator
+  (operators : operators)
+  (owner : address)
+  (operator : operator)
+: operators =
+  if owner = operator
+  then operators
+  (* assert_authorisation always allow the owner so this case is not relevant *)
+
+  else
+    let () = Assertions.assert_update_permission owner in
+    let auths =
+      match Big_map.find_opt owner operators with
+        None -> None
+      | Some (os) ->
+          let os = Set.remove operator os in
+          if (Set.size os = 0n) then None else Some (os) in
+    Big_map.update owner auths operators
+
+// Ledger
+
+let get_for_user (ledger : ledger) (owner : address) : nat =
+  match Big_map.find_opt owner ledger with
+    Some (tokens) -> tokens
+  | None -> 0n
+
+let update_for_user (ledger : ledger) (owner : address) (amount_ : nat)
+: ledger = Big_map.update owner (Some amount_) ledger
+
+let decrease_token_amount_for_user
+  (ledger : ledger)
+  (from_ : address)
+  (amount_ : nat)
+: ledger =
+  let tokens = get_for_user ledger from_ in
+  let () = assert_with_error (tokens >= amount_) Errors.ins_balance in
+  let tokens = abs (tokens - amount_) in
+  let ledger = update_for_user ledger from_ tokens in
+  ledger
+
+let increase_token_amount_for_user
+  (ledger : ledger)
+  (to_ : address)
+  (amount_ : nat)
+: ledger =
+  let tokens = get_for_user ledger to_ in
+  let tokens = tokens + amount_ in
+  let ledger = update_for_user ledger to_ tokens in
+  ledger
+
+// Storage
+
+let get_amount_for_owner (type a) (s : a storage) (owner : address) =
+  get_for_user s.ledger owner
+
+let set_ledger (type a) (s : a storage) (ledger : ledger) = {s with ledger = ledger}
+
+let get_operators (type a) (s : a storage) = s.operators
+
+let set_operators (type a) (s : a storage) (operators : operators) =
+  {s with operators = operators}
+
+let transfer (type a) (t : TZIP12.transfer) (s : a storage) : a ret =
+    (* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se *)
+
+    let process_atomic_transfer
+      (from_ : address)
+      (ledger, t : ledger * TZIP12.atomic_trans) =
+      let {
+       to_;
+       token_id = _token_id;
+       amount = amount_
+      } = t in
+      let () = assert_authorisation s.operators from_ in
+      let ledger = decrease_token_amount_for_user ledger from_ amount_ in
+      let ledger = increase_token_amount_for_user ledger to_ amount_ in
+      ledger in
+    let process_single_transfer (ledger, t : ledger * TZIP12.transfer_from) =
+      let {
+       from_;
+       txs
+      } = t in
+      let ledger = List.fold_left (process_atomic_transfer from_) ledger txs in
+      ledger in
+    let ledger = List.fold_left process_single_transfer s.ledger t in
+    let s = set_ledger s ledger in
+    ([] : operation list), s
+
+let balance_of (type a) (b : TZIP12.balance_of) (s : a storage) : a ret =
+  let {
+     requests;
+     callback
+    } = b in
+    let get_balance_info (request : TZIP12.request) : TZIP12.callback =
+      let {
+       owner;
+       token_id = _token_id
+      } = request in
+      let balance_ = get_amount_for_owner s owner in
+      {
+       request = request;
+       balance = balance_
+      } in
+    let callback_param = List.map get_balance_info requests in
+    let operation = Tezos.transaction (Main callback_param) 0mutez callback in
+    ([operation] : operation list), s
+
+(**
+Add or Remove token operators for the specified token owners and token IDs.
+
+
+The entrypoint accepts a list of update_operator commands. If two different
+commands in the list add and remove an operator for the same token owner and
+token ID, the last command in the list MUST take effect.
+
+
+It is possible to update operators for a token owner that does not hold any token
+balances yet.
+
+
+Operator relation is not transitive. If C is an operator of B and if B is an
+operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
+
+
+*)
+
+let update_operators (type a) (updates : TZIP12.update_operators) (s : a storage) : a ret =
+  let update_operator
+      (operators, update : operators * TZIP12.unit_update) =
+      match update with
+        Add_operator
+          {
+           owner = owner;
+           operator = operator;
+           token_id = _token_id
+          } -> add_operator operators owner operator
+      | Remove_operator
+          {
+           owner = owner;
+           operator = operator;
+           token_id = _token_id
+          } -> remove_operator operators owner operator in
+    let operators = get_operators s in
+    let operators = List.fold_left update_operator operators updates in
+    let s = set_operators s operators in
+    ([] : operation list), s
+
+let get_balance (type a) (p : (address * nat)) (s : a storage) : nat =
+  let (owner, token_id) = p in
+  let () = Assertions.assert_token_exist s.token_metadata token_id in
+  match Big_map.find_opt owner s.ledger with
+    None -> 0n
+  | Some (n) -> n
+
+let total_supply (type a) (_token_id : nat) (_s : a storage) : nat =
+  failwith Errors.not_available
+
+let all_tokens (type a) (_ : unit) (_s : a storage) : nat set =
+  failwith Errors.not_available
+
+let is_operator (type a) (op : TZIP12.operator) (s : a storage) : bool =
+  let authorized =
+    match Big_map.find_opt (op.owner) s.operators with
+      Some (opSet) -> opSet
+    | None -> Set.empty in
+  Set.mem op.operator authorized || op.owner = op.operator
+
+let token_metadata (type a) (p : nat) (s : a storage) : TZIP12.tokenMetadataData =
+  match Big_map.find_opt p s.token_metadata with
+    Some (data) -> data
+  | None () -> failwith Errors.undefined_token
+
+

--- a/lib/fa2/asset/multi_asset.impl.jsligo
+++ b/lib/fa2/asset/multi_asset.impl.jsligo
@@ -1,275 +1,71 @@
 #import "../common/assertions.jsligo" "Assertions"
-
 #import "../common/errors.mligo" "Errors"
-
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
-
-#import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
-
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
+#import "./extendable_multi_asset.impl.jsligo" "MultiAssetExtendable"
 
-export namespace MultiAssetExtendable {
-   export type ledger = big_map<[address, nat], nat>;
-   export type operator = address;
-   export type operators = big_map<[address, operator], set<nat>>;
-   export type storage<T> = {
-      ledger: ledger,
-      operators: operators,
-      token_metadata: TZIP12.tokenMetadata,
-      metadata: TZIP16.metadata,
-      extension: T
-   };
-   type ret<T> = [list<operation>, storage<T>];
-   //operators
-
-   export const assert_authorisation = (
-      [operators, from_, token_id]: [operators, address, nat]
-   ): unit => {
-      const sender_ = (Tezos.get_sender());
-      if (sender_ != from_) {
-         const authorized =
-            match((Big_map.find_opt([from_, sender_], operators))) {
-               when (Some(a)):
-                  a
-               when (None()):
-                  Set.empty
-            };
-         if (! (Set.mem(token_id, authorized))) {
-            return failwith(Errors.not_operator)
-         }
-      }
-   };
-   export const add_operator = (
-      [operators, owner, operator, token_id]: [
-         operators,
-         address,
-         operator,
-         nat
-      ]
-   ): operators => {
-      if (owner == operator) {
-         return operators
-      } // assert_authorisation always allow the owner so this case is not relevant
-       else {
-         Assertions.assert_update_permission(owner);
-         let auth_tokens =
-            match(Big_map.find_opt([owner, operator], operators)) {
-               when (Some(ts)):
-                  ts
-               when (None()):
-                  Set.empty
-            };
-         auth_tokens = Set.add(token_id, auth_tokens);
-         return Big_map.update([owner, operator], Some(auth_tokens), operators)
-      }
-   };
-   export const remove_operator = (
-      [operators, owner, operator, token_id]: [
-         operators,
-         address,
-         operator,
-         nat
-      ]
-   ): operators => {
-      if (owner == operator) {
-         return operators
-      } // assert_authorisation always allow the owner so this case is not relevant
-       else {
-         Assertions.assert_update_permission(owner);
-         const auth_tokens: option<set<nat>> =
-            match(Big_map.find_opt([owner, operator], operators)) {
-               when (Some(toks)):
-                  do {
-                     const ts = Set.remove(token_id, toks);
-                     if (Set.cardinal(ts) == 0n) {
-                        return None()
-                     } else {
-                        return Some(ts)
-                     }
-                  }
-               when (None()):
-                  None()
-            };
-         return Big_map.update([owner, operator], auth_tokens, operators)
-      }
-   }
-   // ledger
-
-   export const get_for_user = (
-      [ledger, owner, token_id]: [ledger, address, nat]
-   ): nat =>
-      match((Big_map.find_opt([owner, token_id], ledger))) {
-         when (Some(a)):
-            a
-         when (None()):
-            0 as nat
-      };
-   const set_for_user = (
-      [ledger, owner, token_id, amount_]: [ledger, address, nat, nat]
-   ): ledger =>
-      Big_map.update([owner, token_id], Some(amount_), ledger);
-   export const decrease_token_amount_for_user = (
-      [ledger, from_, token_id, amount_]: [ledger, address, nat, nat]
-   ): ledger => {
-      let balance_ = get_for_user([ledger, from_, token_id]);
-      assert_with_error((balance_ >= amount_), Errors.ins_balance);
-      balance_ = abs(balance_ - amount_);
-      return set_for_user([ledger, from_, token_id, balance_])
-   };
-   export const increase_token_amount_for_user = (
-      [ledger, to_, token_id, amount_]: [ledger, address, nat, nat]
-   ): ledger => {
-      let balance_ = get_for_user([ledger, to_, token_id]);
-      balance_ = balance_ + amount_;
-      return set_for_user([ledger, to_, token_id, balance_])
-   }
-   // storage
-
-   export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
-      ({ ...s, ledger: ledger });
-   export const get_operators = <T>(s: storage<T>): operators => s.operators;
-   export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
-      ({ ...s, operators: operators })
-
-   export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
-      const process_atomic_transfer = (from_: address) =>
-         ([l, t]: [ledger, TZIP12.atomic_trans]): ledger => {
-            const { to_, token_id, amount } = t;
-            Assertions.assert_token_exist(s.token_metadata, token_id);
-            assert_authorisation([s.operators, from_, token_id]);
-            let ledger =
-               decrease_token_amount_for_user([l, from_, token_id, amount]);
-            ledger
-            = increase_token_amount_for_user([ledger, to_, token_id, amount]);
-            return ledger
-         };
-      const process_single_transfer = ([l, t]: [ledger, TZIP12.transfer_from]): ledger => {
-         const { from_, txs } = t;
-         const ledger = List.fold_left(process_atomic_transfer(from_), l, txs);
-         return ledger
-      };
-      const ledger = List.fold_left(process_single_transfer, s.ledger, t);
-      return [list([]), set_ledger([s, ledger])]
-   };
-
-   export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
-      const { requests, callback } = b;
-      const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
-         const { owner, token_id } = request;
-         Assertions.assert_token_exist(s.token_metadata, token_id);
-         const balance_ = get_for_user([s.ledger, owner, token_id]);
-         return ({ request: request, balance: balance_ })
-      };
-      const callback_param = List.map(get_balance_info, requests);
-      const operation =
-         Tezos.transaction(Main(callback_param), 0mutez, callback);
-      return [list([operation]), s]
-   };
-
-   export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
-      const update_operator = (
-         [operators, update]: [operators, TZIP12.unit_update]
-      ): operators =>
-         match(update) {
-            when (Add_operator(operator)):
-               add_operator(
-                  [
-                     operators,
-                     operator.owner,
-                     operator.operator,
-                     operator.token_id
-                  ]
-               )
-            when (Remove_operator(operator)):
-               remove_operator(
-                  [
-                     operators,
-                     operator.owner,
-                     operator.operator,
-                     operator.token_id
-                  ]
-               )
-         };
-      let operators = get_operators(s);
-      operators = List.fold_left(update_operator, operators, updates);
-      const store = set_operators([s, operators]);
-      return [list([]), store]
-   };
-
-   export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
-      const [owner, token_id] = p;
-      Assertions.assert_token_exist(s.token_metadata, token_id);
-      return match(Big_map.find_opt([owner, token_id], s.ledger)) {
-         when (None()):
-            0n
-         when (Some(n)):
-            n
-      }
-   };
-
-   export const total_supply = <T>(_token_id: nat, _s: storage<T>): nat =>
-      failwith(Errors.not_available);
-
-   export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
-      failwith(Errors.not_available);
-
-   export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
-      const authorized =
-         match(Big_map.find_opt([op.owner, op.operator], s.operators)) {
-            when (Some(opSet)):
-               opSet
-            when (None()):
-               Set.empty
-         };
-      return (Set.size(authorized) > 0n || op.owner == op.operator)
-   };
-
-   export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
-      return match(Big_map.find_opt(p, s.token_metadata)) {
-         when (Some(data)):
-            data
-         when (None()):
-            failwith(Errors.undefined_token)
-      }
-   };
-};
-
-export namespace MultiAsset implements TZIP12Interface.FA2 {
-  export type ledger = MultiAssetExtendable.ledger;
-  export type operator = MultiAssetExtendable.operator;
-  export type operators = MultiAssetExtendable.operators;
-  export type storage = MultiAssetExtendable.storage<unit>;
-  type ret = [list<operation>, storage];
-
-  @entry
-  const transfer = (t: TZIP12.transfer, s: storage): ret =>
-    MultiAssetExtendable.transfer(t, s)
-
-  @entry
-  const balance_of = (b: TZIP12.balance_of, s: storage): ret =>
-    MultiAssetExtendable.balance_of(b, s)
-
-  @entry
-  const update_operators = (updates: TZIP12.update_operators, s: storage): ret =>
-    MultiAssetExtendable.update_operators(updates, s)
-
-  @view
-  const get_balance = (p: [address, nat], s: storage): nat =>
-    MultiAssetExtendable.get_balance(p, s)
-
-  @view
-  const total_supply = (token_id: nat, s: storage): nat =>
-    MultiAssetExtendable.total_supply(token_id, s)
-
-  @view
-  const all_tokens = (_: unit, s: storage): set<nat> =>
-    MultiAssetExtendable.all_tokens(unit, s)
-
-  @view
-  const is_operator = (op: TZIP12.operator, s: storage): bool =>
-    MultiAssetExtendable.is_operator(op, s)
-
-  @view
-  const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData =>
-    MultiAssetExtendable.token_metadata(p, s)
+export type ledger = MultiAssetExtendable.ledger;
+export type operator = MultiAssetExtendable.operator;
+export type operators = MultiAssetExtendable.operators;
+export type storage = {
+   ledger : ledger,
+   operators : operators,
+   token_metadata : TZIP12.tokenMetadata,
+   metadata : TZIP16.metadata,
 }
+
+type ret = [list<operation>, storage];
+
+@inline
+const lift = (s: storage): MultiAssetExtendable.storage<unit> => {
+  return {
+    extension: unit,
+    ledger: s.ledger,
+    operators: s.operators,
+    token_metadata: s.token_metadata,
+    metadata: s.metadata
+  };
+}
+
+@inline
+const unlift = ([ops, s]: [list<operation>, MultiAssetExtendable.storage<unit>]): ret => {
+  let storage = {
+    ledger: s.ledger,
+    operators: s.operators,
+    token_metadata: s.token_metadata,
+    metadata: s.metadata
+  };
+  return [ops, storage];
+}
+
+@entry
+const transfer = (t: TZIP12.transfer, s: storage): ret =>
+  unlift(MultiAssetExtendable.transfer(t, lift(s)))
+
+@entry
+const balance_of = (b: TZIP12.balance_of, s: storage): ret =>
+  unlift(MultiAssetExtendable.balance_of(b, lift(s)))
+
+@entry
+const update_operators = (updates: TZIP12.update_operators, s: storage): ret =>
+  unlift(MultiAssetExtendable.update_operators(updates, lift(s)))
+
+@view
+const get_balance = (p: [address, nat], s: storage): nat =>
+  MultiAssetExtendable.get_balance(p, lift(s))
+
+@view
+const total_supply = (token_id: nat, s: storage): nat =>
+  MultiAssetExtendable.total_supply(token_id, lift(s))
+
+@view
+const all_tokens = (_: unit, s: storage): set<nat> =>
+  MultiAssetExtendable.all_tokens(unit, lift(s))
+
+@view
+const is_operator = (op: TZIP12.operator, s: storage): bool =>
+  MultiAssetExtendable.is_operator(op, lift(s))
+
+@view
+const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData =>
+  MultiAssetExtendable.token_metadata(p, lift(s))

--- a/lib/fa2/asset/multi_asset.impl.mligo
+++ b/lib/fa2/asset/multi_asset.impl.mligo
@@ -57,14 +57,13 @@ let update_operators (updates : TZIP12.update_operators) (s : storage) : ret =
 let get_balance (p : (address * nat)) (s : storage) : nat =
   MultiAssetExtendable.get_balance p (lift s)
 
-(* FIXME Not sure why we are implementing the two following views *)
 [@view]
-let total_supply (_token_id : nat) (_s : storage) : nat =
-  failwith Errors.not_available
+let total_supply (token_id : nat) (s : storage) : nat =
+  MultiAssetExtendable.total_supply token_id (lift s)
 
 [@view]
-let all_tokens (_ : unit) (_s : storage) : nat set =
-  failwith Errors.not_available
+let all_tokens (_ : unit) (s : storage) : nat set =
+  MultiAssetExtendable.all_tokens () (lift s)
 
 [@view]
 let is_operator (op : TZIP12.operator) (s : storage) : bool =

--- a/lib/fa2/asset/single_asset.impl.jsligo
+++ b/lib/fa2/asset/single_asset.impl.jsligo
@@ -1,266 +1,73 @@
 #import "../common/assertions.jsligo" "Assertions"
-
 #import "../common/errors.mligo" "Errors"
-
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
-
 #import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
-
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
+#import "./extendable_single_asset.impl.jsligo" "SingleAssetExtendable"
 
-export namespace SingleAssetExtendable {
-   export type ledger = big_map<address, nat>;
-   export type operator = address;
-   export type operators = big_map<address, set<operator>>;
-   export type storage<T> = {
-      ledger: ledger,
-      operators: operators,
-      token_metadata: TZIP12.tokenMetadata,
-      metadata: TZIP16.metadata,
-      extension: T
-   };
-   type ret<T> = [list<operation>, storage<T>];
-   // operators
-
-   export const assert_authorisation = (operators: operators, from_: address): unit => {
-      const sender_ = Tezos.get_sender();
-      if (sender_ == from_) return unit else {
-         const authorized =
-            match(Big_map.find_opt(from_, operators)) {
-               when (Some(a)):
-                  a
-               when (None()):
-                  Set.empty
-            };
-         if (Set.mem(sender_, authorized)) return unit else failwith(
-            Errors.not_operator
-         )
-      }
-   };
-   export const add_operator = (
-      operators: operators,
-      owner: address,
-      operator: operator
-   ): operators => {
-      if (owner == operator) return operators else {
-         const _ = Assertions.assert_update_permission(owner);
-         let auths =
-            match(Big_map.find_opt(owner, operators)) {
-               when (Some(os)):
-                  os
-               when (None()):
-                  Set.empty
-            };
-         auths = Set.add(operator, auths);
-         return Big_map.update(owner, Some(auths), operators)
-      }
-   };
-   export const remove_operator = (
-      operators: operators,
-      owner: address,
-      operator: operator
-   ): operators => {
-      if (owner == operator) return operators else {
-         const _ = Assertions.assert_update_permission(owner);
-         const auths =
-            match(Big_map.find_opt(owner, operators)) {
-               when (None()):
-                  None()
-               when (Some(ops)):
-                  do {
-                     let os = Set.remove(operator, ops);
-                     if (Set.size(os) == 0n) return None() else return Some(os)
-                  }
-            };
-         return Big_map.update(owner, auths, operators)
-      }
-   }
-   // ledger
-
-   export const get_for_user = (ledger: ledger, owner: address): nat =>
-      match(Big_map.find_opt(owner, ledger)) {
-         when (Some(tokens)):
-            tokens
-         when (None()):
-            0 as nat
-      };
-   const update_for_user = (ledger: ledger, owner: address, amount_: nat): ledger =>
-      Big_map.update(owner, Some(amount_), ledger);
-   export const decrease_token_amount_for_user = (
-      ledger: ledger,
-      from_: address,
-      amount_: nat
-   ): ledger => {
-      let tokens = get_for_user(ledger, from_);
-      const _ = assert_with_error(tokens >= amount_, Errors.ins_balance);
-      tokens = abs(tokens - amount_);
-      return update_for_user(ledger, from_, tokens)
-   };
-   export const increase_token_amount_for_user = (
-      ledger: ledger,
-      to_: address,
-      amount_: nat
-   ): ledger => {
-      let tokens = get_for_user(ledger, to_);
-      tokens = tokens + amount_;
-      return update_for_user(ledger, to_, tokens)
-   }
-   // Storage
-
-   export const get_amount_for_owner = <T>(s: storage<T>, owner: address) =>
-      get_for_user(s.ledger, owner);
-   export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
-      ({ ...s, ledger: ledger });
-   export const get_operators = <T>(s: storage<T>): operators => s.operators;
-   export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
-      ({ ...s, operators: operators })
-
-    export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
-      /* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se */
-
-      const process_atomic_transfer = (from_: address) =>
-         ([ledger, t]: [ledger, TZIP12.atomic_trans]): ledger => {
-            const { to_, token_id, amount } = t;
-            ignore(token_id);
-            const _ = assert_authorisation(s.operators, from_);
-            let l = decrease_token_amount_for_user(ledger, from_, amount);
-            return increase_token_amount_for_user(l, to_, amount)
-         };
-      const process_single_transfer = (
-         [ledger, t]: [ledger, TZIP12.transfer_from]
-      ): ledger => {
-         const { from_, txs } = t;
-         return List.fold_left(process_atomic_transfer(from_), ledger, txs)
-      };
-      const ledger = List.fold_left(process_single_transfer, s.ledger, t);
-      const store = set_ledger([s, ledger]);
-      return [list([]), store]
-   };
-   /** balance_of entrypoint
-*/
-
-   export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
-      const { requests, callback } = b;
-      const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
-         const { owner, token_id } = request;
-         ignore(token_id);
-         const balance_ = get_amount_for_owner(s, owner);
-         return { request: request, balance: balance_ }
-      };
-      const callback_param = List.map(get_balance_info, requests);
-      const operation =
-         Tezos.transaction(Main(callback_param), 0mutez, callback);
-      return [list([operation]), s]
-   };
-   /**
-Add or Remove token operators for the specified token owners and token IDs.
-
-
-The entrypoint accepts a list of update_operator commands. If two different
-commands in the list add and remove an operator for the same token owner and
-token ID, the last command in the list MUST take effect.
-
-
-It is possible to update operators for a token owner that does not hold any token
-balances yet.
-
-
-Operator relation is not transitive. If C is an operator of B and if B is an
-operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
-
-
-*/
-
-   export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
-      const update_operator = (
-         [operators, update]: [operators, TZIP12.unit_update]
-      ): operators =>
-         match(update) {
-            when (Add_operator(operator)):
-               add_operator(operators, operator.owner, operator.operator)
-            when (Remove_operator(operator)):
-               remove_operator(operators, operator.owner, operator.operator)
-         };
-      const operators =
-         List.fold_left(update_operator, get_operators(s), updates);
-      const store = set_operators([s, operators]);
-      return [list([]), store]
-   };
-
-   export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
-      const [owner, token_id] = p;
-      Assertions.assert_token_exist(s.token_metadata, token_id);
-      return match(Big_map.find_opt(owner, s.ledger)) {
-         when (None()):
-            0n
-         when (Some(n)):
-            n
-      }
-   };
-
-   export const total_supply = <T>(_token_id: nat, _s: storage<T>): nat =>
-      failwith(Errors.not_available);
-
-   export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
-      failwith(Errors.not_available);
-
-   export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
-      const authorized =
-         match(Big_map.find_opt(op.owner, s.operators)) {
-            when (Some(opSet)):
-               opSet
-            when (None()):
-               Set.empty
-         };
-      return (Set.mem(op.operator, authorized) || op.owner == op.operator)
-   };
-
-   export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
-      return match(Big_map.find_opt(p, s.token_metadata)) {
-         when (Some(data)):
-            data
-         when (None()):
-            failwith(Errors.undefined_token)
-      }
-   };
-};
-
-export namespace SingleAsset implements TZIP12Interface.FA2 {
-  export type ledger = SingleAssetExtendable.ledger;
-  export type operator = SingleAssetExtendable.operator;
-  export type operators = SingleAssetExtendable.operators;
-  export type storage = SingleAssetExtendable.storage<unit>;
-  type ret = [list<operation>, storage];
-
-  @entry
-  const transfer = (t: TZIP12.transfer, s: storage): ret =>
-    SingleAssetExtendable.transfer(t, s)
-
-  @entry
-  const balance_of = (b: TZIP12.balance_of, s: storage): ret =>
-    SingleAssetExtendable.balance_of(b, s)
-
-  @entry
-  const update_operators = (updates: TZIP12.update_operators, s: storage): ret =>
-    SingleAssetExtendable.update_operators(updates, s)
-
-  @view
-  const get_balance = (p: [address, nat], s: storage): nat =>
-    SingleAssetExtendable.get_balance(p, s)
-
-  @view
-  const total_supply = (token_id: nat, s: storage): nat =>
-    SingleAssetExtendable.total_supply(token_id, s)
-
-  @view
-  const all_tokens = (_: unit, s: storage): set<nat> =>
-    SingleAssetExtendable.all_tokens(unit, s)
-
-  @view
-  const is_operator = (op: TZIP12.operator, s: storage): bool =>
-    SingleAssetExtendable.is_operator(op, s)
-
-  @view
-  const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData =>
-    SingleAssetExtendable.token_metadata(p, s)
+export type ledger = SingleAssetExtendable.ledger;
+export type operator = SingleAssetExtendable.operator;
+export type operators = SingleAssetExtendable.operators;
+export type storage = SingleAssetExtendable.storage<unit>;
+export type storage = {
+   ledger : ledger,
+   operators : operators,
+   token_metadata : TZIP12.tokenMetadata,
+   metadata : TZIP16.metadata,
 }
+
+type ret = [list<operation>, storage];
+
+@inline
+const lift = (s: storage): SingleAssetExtendable.storage<unit> => {
+  return {
+    extension: unit,
+    ledger: s.ledger,
+    operators: s.operators,
+    token_metadata: s.token_metadata,
+    metadata: s.metadata
+  };
+}
+
+@inline
+const unlift = ([ops, s]: [list<operation>, SingleAssetExtendable.storage<unit>]): ret => {
+  let storage = {
+    ledger: s.ledger,
+    operators: s.operators,
+    token_metadata: s.token_metadata,
+    metadata: s.metadata
+  };
+  return [ops, storage];
+}
+
+@entry
+const transfer = (t: TZIP12.transfer, s: storage): ret =>
+  unlift(SingleAssetExtendable.transfer(t, lift(s)))
+
+@entry
+const balance_of = (b: TZIP12.balance_of, s: storage): ret =>
+  unlift(SingleAssetExtendable.balance_of(b, lift(s)))
+
+@entry
+const update_operators = (updates: TZIP12.update_operators, s: storage): ret =>
+  unlift(SingleAssetExtendable.update_operators(updates, lift(s)))
+
+@view
+const get_balance = (p: [address, nat], s: storage): nat =>
+  SingleAssetExtendable.get_balance(p, lift(s))
+
+@view
+const total_supply = (token_id: nat, s: storage): nat =>
+  SingleAssetExtendable.total_supply(token_id, lift(s))
+
+@view
+const all_tokens = (_: unit, s: storage): set<nat> =>
+  SingleAssetExtendable.all_tokens(unit, lift(s))
+
+@view
+const is_operator = (op: TZIP12.operator, s: storage): bool =>
+  SingleAssetExtendable.is_operator(op, lift(s))
+
+@view
+const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData =>
+  SingleAssetExtendable.token_metadata(p, lift(s))

--- a/lib/fa2/asset/single_asset.impl.mligo
+++ b/lib/fa2/asset/single_asset.impl.mligo
@@ -3,269 +3,75 @@
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
 #import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
-module SingleAssetExtendable = struct
-  type ledger = (address, nat) big_map
+#import "./extendable_single_asset.impl.mligo" "SingleAssetExtendable"
 
-  type operator = address
+type ledger = SingleAssetExtendable.ledger
 
-  type operators = (address, operator set) big_map
+type operator = SingleAssetExtendable.operator
 
-  type 'a storage = {
-     ledger : ledger;
-     operators : operators;
-     token_metadata : TZIP12.tokenMetadata;
-     metadata : TZIP16.metadata;
-     extension: 'a
-    }
+type operators = SingleAssetExtendable.operators
 
-  type 'a ret = operation list * 'a storage
+type storage = unit SingleAssetExtendable.storage
 
-  // Operators
+type storage = {
+   ledger : ledger;
+   operators : operators;
+   token_metadata : TZIP12.tokenMetadata;
+   metadata : TZIP16.metadata;
+}
 
-  let assert_authorisation (operators : operators) (from_ : address) : unit =
-    let sender_ = (Tezos.get_sender ()) in
-    if (sender_ = from_)
-    then ()
-    else
-      let authorized =
-        match Big_map.find_opt from_ operators with
-          Some (a) -> a
-        | None -> Set.empty in
-      if Set.mem sender_ authorized then () else failwith Errors.not_operator
+type ret = operation list * storage
 
-  let add_operator
-    (operators : operators)
-    (owner : address)
-    (operator : operator)
-  : operators =
-    if owner = operator
-    then operators
-    (* assert_authorisation always allow the owner so this case is not relevant *)
+[@inline]
+let lift (s : storage) : unit SingleAssetExtendable.storage =
+  {
+    extension = ();
+    ledger = s.ledger;
+    operators = s.operators;
+    token_metadata = s.token_metadata;
+    metadata = s.metadata;
+  }
 
-    else
-      let () = Assertions.assert_update_permission owner in
-      let auths =
-        match Big_map.find_opt owner operators with
-          Some (os) -> os
-        | None -> Set.empty in
-      let auths = Set.add operator auths in
-      Big_map.update owner (Some auths) operators
+[@inline]
+let unlift (ret : operation list * unit SingleAssetExtendable.storage) : ret =
+  let ops, s = ret in
+  ops,
+  {
+    ledger = s.ledger;
+    operators = s.operators;
+    token_metadata = s.token_metadata;
+    metadata = s.metadata;
+  }
 
-  let remove_operator
-    (operators : operators)
-    (owner : address)
-    (operator : operator)
-  : operators =
-    if owner = operator
-    then operators
-    (* assert_authorisation always allow the owner so this case is not relevant *)
+[@entry]
+let transfer (t : TZIP12.transfer) (s : storage) : ret =
+  unlift (SingleAssetExtendable.transfer t (lift s))
 
-    else
-      let () = Assertions.assert_update_permission owner in
-      let auths =
-        match Big_map.find_opt owner operators with
-          None -> None
-        | Some (os) ->
-            let os = Set.remove operator os in
-            if (Set.size os = 0n) then None else Some (os) in
-      Big_map.update owner auths operators
+[@entry]
+let balance_of (b : TZIP12.balance_of) (s : storage) : ret =
+  unlift (SingleAssetExtendable.balance_of b (lift s))
 
-  // Ledger
+[@entry]
+let update_operators (updates : TZIP12.update_operators) (s : storage) : ret =
+  unlift (SingleAssetExtendable.update_operators updates (lift s))
 
-  let get_for_user (ledger : ledger) (owner : address) : nat =
-    match Big_map.find_opt owner ledger with
-      Some (tokens) -> tokens
-    | None -> 0n
+[@view]
+let get_balance (p : (address * nat)) (s : storage) : nat =
+  SingleAssetExtendable.get_balance p (lift s)
 
-  let update_for_user (ledger : ledger) (owner : address) (amount_ : nat)
-  : ledger = Big_map.update owner (Some amount_) ledger
+(* FIXME Not sure why we are implementing the two following views *)
+[@view]
+let total_supply (_token_id : nat) (_s : storage) : nat =
+  failwith Errors.not_available
 
-  let decrease_token_amount_for_user
-    (ledger : ledger)
-    (from_ : address)
-    (amount_ : nat)
-  : ledger =
-    let tokens = get_for_user ledger from_ in
-    let () = assert_with_error (tokens >= amount_) Errors.ins_balance in
-    let tokens = abs (tokens - amount_) in
-    let ledger = update_for_user ledger from_ tokens in
-    ledger
+[@view]
+let all_tokens (_ : unit) (_s : storage) : nat set =
+  failwith Errors.not_available
 
-  let increase_token_amount_for_user
-    (ledger : ledger)
-    (to_ : address)
-    (amount_ : nat)
-  : ledger =
-    let tokens = get_for_user ledger to_ in
-    let tokens = tokens + amount_ in
-    let ledger = update_for_user ledger to_ tokens in
-    ledger
+[@view]
+let is_operator (op : TZIP12.operator) (s : storage) : bool =
+  SingleAssetExtendable.is_operator op (lift s)
 
-  // Storage
-
-  let get_amount_for_owner (type a) (s : a storage) (owner : address) =
-    get_for_user s.ledger owner
-
-  let set_ledger (type a) (s : a storage) (ledger : ledger) = {s with ledger = ledger}
-
-  let get_operators (type a) (s : a storage) = s.operators
-
-  let set_operators (type a) (s : a storage) (operators : operators) =
-    {s with operators = operators}
-
-  let transfer (type a) (t : TZIP12.transfer) (s : a storage) : a ret =
-      (* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se *)
-
-      let process_atomic_transfer
-        (from_ : address)
-        (ledger, t : ledger * TZIP12.atomic_trans) =
-        let {
-         to_;
-         token_id = _token_id;
-         amount = amount_
-        } = t in
-        let () = assert_authorisation s.operators from_ in
-        let ledger = decrease_token_amount_for_user ledger from_ amount_ in
-        let ledger = increase_token_amount_for_user ledger to_ amount_ in
-        ledger in
-      let process_single_transfer (ledger, t : ledger * TZIP12.transfer_from) =
-        let {
-         from_;
-         txs
-        } = t in
-        let ledger = List.fold_left (process_atomic_transfer from_) ledger txs in
-        ledger in
-      let ledger = List.fold_left process_single_transfer s.ledger t in
-      let s = set_ledger s ledger in
-      ([] : operation list), s
-
-  let balance_of (type a) (b : TZIP12.balance_of) (s : a storage) : a ret =
-    let {
-       requests;
-       callback
-      } = b in
-      let get_balance_info (request : TZIP12.request) : TZIP12.callback =
-        let {
-         owner;
-         token_id = _token_id
-        } = request in
-        let balance_ = get_amount_for_owner s owner in
-        {
-         request = request;
-         balance = balance_
-        } in
-      let callback_param = List.map get_balance_info requests in
-      let operation = Tezos.transaction (Main callback_param) 0mutez callback in
-      ([operation] : operation list), s
-
-  (**
-Add or Remove token operators for the specified token owners and token IDs.
-
-
-The entrypoint accepts a list of update_operator commands. If two different
-commands in the list add and remove an operator for the same token owner and
-token ID, the last command in the list MUST take effect.
-
-
-It is possible to update operators for a token owner that does not hold any token
-balances yet.
-
-
-Operator relation is not transitive. If C is an operator of B and if B is an
-operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
-
-
-*)
-
-  let update_operators (type a) (updates : TZIP12.update_operators) (s : a storage) : a ret =
-    let update_operator
-        (operators, update : operators * TZIP12.unit_update) =
-        match update with
-          Add_operator
-            {
-             owner = owner;
-             operator = operator;
-             token_id = _token_id
-            } -> add_operator operators owner operator
-        | Remove_operator
-            {
-             owner = owner;
-             operator = operator;
-             token_id = _token_id
-            } -> remove_operator operators owner operator in
-      let operators = get_operators s in
-      let operators = List.fold_left update_operator operators updates in
-      let s = set_operators s operators in
-      ([] : operation list), s
-
-  let get_balance (type a) (p : (address * nat)) (s : a storage) : nat =
-    let (owner, token_id) = p in
-    let () = Assertions.assert_token_exist s.token_metadata token_id in
-    match Big_map.find_opt owner s.ledger with
-      None -> 0n
-    | Some (n) -> n
-
-  let total_supply (type a) (_token_id : nat) (_s : a storage) : nat =
-    failwith Errors.not_available
-
-  let all_tokens (type a) (_ : unit) (_s : a storage) : nat set =
-    failwith Errors.not_available
-
-  let is_operator (type a) (op : TZIP12.operator) (s : a storage) : bool =
-    let authorized =
-      match Big_map.find_opt (op.owner) s.operators with
-        Some (opSet) -> opSet
-      | None -> Set.empty in
-    Set.mem op.operator authorized || op.owner = op.operator
-
-  let token_metadata (type a) (p : nat) (s : a storage) : TZIP12.tokenMetadataData =
-    match Big_map.find_opt p s.token_metadata with
-      Some (data) -> data
-    | None () -> failwith Errors.undefined_token
-
-end
-
-module SingleAsset = struct
-  type ledger = SingleAssetExtendable.ledger
-
-  type operator = SingleAssetExtendable.operator
-
-  type operators = SingleAssetExtendable.operators
-
-  type storage = unit SingleAssetExtendable.storage
-
-  type ret = unit SingleAssetExtendable.ret
-
-  [@entry]
-  let transfer (t : TZIP12.transfer) (s : storage) : ret =
-    SingleAssetExtendable.transfer t s
-
-  [@entry]
-  let balance_of (b : TZIP12.balance_of) (s : storage) : ret =
-    SingleAssetExtendable.balance_of b s
-
-  [@entry]
-  let update_operators (updates : TZIP12.update_operators) (s : storage) : ret =
-    SingleAssetExtendable.update_operators updates s
-
-  [@view]
-  let get_balance (p : (address * nat)) (s : storage) : nat =
-    SingleAssetExtendable.get_balance p s
-
-  (* FIXME Not sure why we are implementing the two following views *)
-  [@view]
-  let total_supply (_token_id : nat) (_s : storage) : nat =
-    failwith Errors.not_available
-
-  [@view]
-  let all_tokens (_ : unit) (_s : storage) : nat set =
-    failwith Errors.not_available
-
-  [@view]
-  let is_operator (op : TZIP12.operator) (s : storage) : bool =
-    SingleAssetExtendable.is_operator op s
-
-  [@view]
-  let token_metadata (p : nat) (s : storage) : TZIP12.tokenMetadataData =
-    SingleAssetExtendable.token_metadata p s
-end
+[@view]
+let token_metadata (p : nat) (s : storage) : TZIP12.tokenMetadataData =
+  SingleAssetExtendable.token_metadata p (lift s)

--- a/lib/fa2/asset/single_asset.impl.mligo
+++ b/lib/fa2/asset/single_asset.impl.mligo
@@ -59,14 +59,13 @@ let update_operators (updates : TZIP12.update_operators) (s : storage) : ret =
 let get_balance (p : (address * nat)) (s : storage) : nat =
   SingleAssetExtendable.get_balance p (lift s)
 
-(* FIXME Not sure why we are implementing the two following views *)
 [@view]
-let total_supply (_token_id : nat) (_s : storage) : nat =
-  failwith Errors.not_available
+let total_supply (token_id : nat) (s : storage) : nat =
+  SingleAssetExtendable.total_supply token_id (lift s)
 
 [@view]
-let all_tokens (_ : unit) (_s : storage) : nat set =
-  failwith Errors.not_available
+let all_tokens (_ : unit) (s : storage) : nat set =
+  SingleAssetExtendable.all_tokens () (lift s)
 
 [@view]
 let is_operator (op : TZIP12.operator) (s : storage) : bool =

--- a/lib/fa2/common/tzip12.interfaces.jsligo
+++ b/lib/fa2/common/tzip12.interfaces.jsligo
@@ -16,11 +16,11 @@ export interface FA2 {
   /* Mandatory storage to be recognized as TZIP12 contract*/
 
   type storage = {
+    extension: unit,
     ledger: ledger,
     operators: operators,
     token_metadata: TZIP12Datatypes.tokenMetadata,
     metadata: TZIP16Datatypes.metadata,
-    extension: unit
   };
   type ret = [list<operation>, storage];
   /**

--- a/lib/fa2/nft/extendable_nft.impl.jsligo
+++ b/lib/fa2/nft/extendable_nft.impl.jsligo
@@ -1,0 +1,235 @@
+#import "../common/assertions.jsligo" "Assertions"
+#import "../common/errors.mligo" "Errors"
+#import "../common/tzip12.datatypes.jsligo" "TZIP12"
+#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+
+export type ledger = big_map<nat, address>;
+export type operator = address;
+export type operators = big_map<[address, operator], set<nat>>; //[owner,operator]
+
+export type storage<T> = {
+  ledger: ledger,
+  operators: operators,
+  token_metadata: TZIP12.tokenMetadata,
+  metadata: TZIP16.metadata,
+  extension: T
+};
+type ret<T> = [list<operation>, storage<T>];
+//** LIGOFA_NFT
+
+export const assert_authorisation = (
+  operators: operators,
+  from_: address,
+  token_id: nat
+): unit => {
+  const sender_ = (Tezos.get_sender());
+  if (sender_ != from_) {
+     const authorized =
+        match((Big_map.find_opt([from_, sender_], operators))) {
+           when (Some(a)):
+              a
+           when (None()):
+              Set.empty
+        };
+     if (! (Set.mem(token_id, authorized))) {
+        return failwith(Errors.not_operator)
+     }
+  } else {
+     return unit
+  }
+};
+export const add_operator = (
+  operators: operators,
+  owner: address,
+  operator: address,
+  token_id: nat
+): operators => {
+  if (owner == operator) {
+     return operators
+  // assert_authorisation always allow the owner so this case is not relevant
+
+  } else {
+     Assertions.assert_update_permission(owner);
+     let auth_tokens =
+        match(Big_map.find_opt([owner, operator], operators)) {
+           when (Some(ts)):
+              ts
+           when (None()):
+              Set.empty
+        };
+     auth_tokens = Set.add(token_id, auth_tokens);
+     return Big_map.update([owner, operator], Some(auth_tokens), operators)
+  }
+};
+export const remove_operator = (
+  operators: operators,
+  owner: address,
+  operator: address,
+  token_id: nat
+): operators => {
+  if (owner == operator) {
+     return operators
+  // assert_authorisation always allow the owner so this case is not relevant
+
+  } else {
+     Assertions.assert_update_permission(owner);
+     const auth_tokens: option<set<nat>> =
+        match(Big_map.find_opt([owner, operator], operators)) {
+           when (Some(ts)):
+              do {
+                 const toks = Set.remove(token_id, ts);
+                 if (Set.cardinal(toks) == 0n) {
+                    return None()
+                 } else {
+                    return Some(toks)
+                 }
+              }
+           when (None()):
+              None()
+        };
+     return Big_map.update([owner, operator], auth_tokens, operators)
+  }
+}
+//  ledger
+
+export const is_owner_of = (ledger: ledger, token_id: nat, owner: address): bool => {
+  const current_owner = Option.unopt(Big_map.find_opt(token_id, ledger));
+  return (current_owner == owner)
+};
+export const assert_owner_of = (
+  ledger: ledger,
+  token_id: nat,
+  owner: address
+): unit =>
+  assert_with_error(
+     is_owner_of(ledger, token_id, owner),
+     Errors.ins_balance
+  );
+export const transfer_token_from_user_to_user = (
+  ledger: ledger,
+  token_id: nat,
+  from_: address,
+  to_: address
+): ledger => {
+  assert_owner_of(ledger, token_id, from_);
+  return Big_map.update(token_id, Some(to_), ledger)
+}
+
+export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
+  ({ ...s, ledger: ledger });
+export const get_operators = <T>(s: storage<T>): operators => s.operators;
+export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
+  ({ ...s, operators: operators })
+
+//** TZIP12Interface.FA2
+//  operators
+/**
+* Check if the intented transfer is sent from the same sender as from field, otherwise check if the sender is part of the operator authorized to receive this token
+* @param operators :  operator bigmap
+* @param from_ : transfer from address
+* @param token_id : token_id to test
+*/
+
+export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
+  const process_atomic_transfer = (from_: address) =>
+     ([ledger, t]: [ledger, TZIP12.atomic_trans]): ledger => {
+        const { to_, token_id, amount } = t;
+        ignore(amount);
+        Assertions.assert_token_exist(s.token_metadata, token_id);
+        assert_authorisation(s.operators, from_, token_id);
+        return transfer_token_from_user_to_user(
+           ledger,
+           token_id,
+           from_,
+           to_
+        )
+     };
+  const process_single_transfer = (
+     [ledger, t]: [ledger, TZIP12.transfer_from]
+  ): ledger => {
+     const { from_, txs } = t;
+     return List.fold_left(process_atomic_transfer(from_), ledger, txs)
+  };
+  const ledger = List.fold_left(process_single_transfer, s.ledger, t);
+  const store = set_ledger([s, ledger]);
+  return [list([]), store]
+};
+
+export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
+  const { requests, callback } = b;
+  const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
+     const { owner, token_id } = request;
+     Assertions.assert_token_exist(s.token_metadata, token_id);
+     let balance_ = 0 as nat;
+     if (is_owner_of(s.ledger, token_id, owner)) balance_ = 1 as nat;
+     return ({ request: request, balance: balance_ })
+  };
+  const callback_param = List.map(get_balance_info, requests);
+  const operation =
+     Tezos.transaction(Main(callback_param), 0mutez, callback);
+  return [list([operation]), s]
+};
+
+export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
+  const update_operator = (
+     [operators, update]: [operators, TZIP12.unit_update]
+  ): operators =>
+     match(update) {
+        when (Add_operator(operator)):
+           add_operator(
+              operators,
+              operator.owner,
+              operator.operator,
+              operator.token_id
+           )
+        when (Remove_operator(operator)):
+           remove_operator(
+              operators,
+              operator.owner,
+              operator.operator,
+              operator.token_id
+           )
+     };
+  let operators = get_operators(s);
+  operators = List.fold_left(update_operator, operators, updates);
+  const store = set_operators([s, operators]);
+  return [list([]), store]
+};
+
+export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
+  const [owner, token_id] = p;
+  Assertions.assert_token_exist(s.token_metadata, token_id);
+  if (is_owner_of(s.ledger, token_id, owner)) {
+     return 1n
+  } else {
+     return 0n
+  }
+};
+
+export const total_supply = <T>(token_id: nat, s: storage<T>): nat => {
+  Assertions.assert_token_exist(s.token_metadata, token_id);
+  return 1n
+};
+
+export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
+  failwith(Errors.not_available);
+
+export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
+  const authorized =
+     match(Big_map.find_opt([op.owner, op.operator], s.operators)) {
+        when (Some(a)):
+           a
+        when (None()):
+           Set.empty
+     };
+  return (Set.mem(op.token_id, authorized) || op.owner == op.operator)
+};
+
+export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
+  return match(Big_map.find_opt(p, s.token_metadata)) {
+     when (Some(data)):
+        data
+     when (None()):
+        failwith(Errors.undefined_token)
+  }
+}

--- a/lib/fa2/nft/extendable_nft.impl.mligo
+++ b/lib/fa2/nft/extendable_nft.impl.mligo
@@ -125,6 +125,12 @@ let get_balance (type a) (s : a storage) (owner : address) (token_id : nat) : na
   let () = Assertions.assert_token_exist s.token_metadata token_id in
   if is_owner_of s owner token_id then 1n else 0n
 
+let set_balance (type a) (s : a storage) (owner : address) (token_id : nat) : a storage =
+  let () = Assertions.assert_token_exist s.token_metadata token_id in
+  let previous, new_ledger = Big_map.get_and_update token_id (Some owner) s.ledger in
+  let () = assert (Option.is_none previous) in
+  set_ledger s new_ledger
+
 let transfer (type a) (t : TZIP12.transfer) (s : a storage) : a ret =
   (* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se *)
 
@@ -195,6 +201,7 @@ let get_balance (type a) (p : address * nat) (s : a storage) =
   let balance_ = get_balance s owner token_id in
   balance_
 
+(* FIXME? Dynamic supply *)
 let total_supply (type a) (token_id : nat) (s : a storage) =
   let () = Assertions.assert_token_exist s.token_metadata token_id in
   1n

--- a/lib/fa2/nft/extendable_nft.impl.mligo
+++ b/lib/fa2/nft/extendable_nft.impl.mligo
@@ -127,8 +127,7 @@ let get_balance (type a) (s : a storage) (owner : address) (token_id : nat) : na
 
 let set_balance (type a) (s : a storage) (owner : address) (token_id : nat) : a storage =
   let () = Assertions.assert_token_exist s.token_metadata token_id in
-  let previous, new_ledger = Big_map.get_and_update token_id (Some owner) s.ledger in
-  let () = assert (Option.is_none previous) in
+  let new_ledger = Big_map.update token_id (Some owner) s.ledger in
   set_ledger s new_ledger
 
 let transfer (type a) (t : TZIP12.transfer) (s : a storage) : a ret =

--- a/lib/fa2/nft/extendable_nft.impl.mligo
+++ b/lib/fa2/nft/extendable_nft.impl.mligo
@@ -1,0 +1,217 @@
+#import "../common/assertions.jsligo" "Assertions"
+#import "../common/errors.mligo" "Errors"
+#import "../common/tzip12.datatypes.jsligo" "TZIP12"
+#import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
+#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+
+type ledger = (nat, address) big_map
+
+type operator = address
+
+type operators = ((address * operator), nat set) big_map
+
+type 'a storage =
+  {
+   extension: 'a;
+   ledger : ledger;
+   operators : operators;
+   token_metadata : TZIP12.tokenMetadata;
+   metadata : TZIP16.metadata;
+  }
+
+type 'a ret = operation list * 'a storage
+
+// Operators
+
+let assert_authorisation
+  (operators : operators)
+  (from_ : address)
+  (token_id : nat)
+: unit =
+  let sender_ = (Tezos.get_sender ()) in
+  if (sender_ = from_)
+  then ()
+  else
+    let authorized =
+      match Big_map.find_opt (from_, sender_) operators with
+        Some (a) -> a
+      | None -> Set.empty in
+    if Set.mem token_id authorized then () else failwith Errors.not_operator
+
+let is_operator
+  (operators, owner, operator, token_id
+   : (operators * address * address * nat))
+: bool =
+  let authorized =
+    match Big_map.find_opt (owner, operator) operators with
+      Some (a) -> a
+    | None -> Set.empty in
+  (owner = operator || Set.mem token_id authorized)
+
+let add_operator
+  (operators : operators)
+  (owner : address)
+  (operator : operator)
+  (token_id : nat)
+: operators =
+  if owner = operator
+  then operators
+  (* assert_authorisation always allow the owner so this case is not relevant *)
+
+  else
+    let () = Assertions.assert_update_permission owner in
+    let auth_tokens =
+      match Big_map.find_opt (owner, operator) operators with
+        Some (ts) -> ts
+      | None -> Set.empty in
+    let auth_tokens = Set.add token_id auth_tokens in
+    Big_map.update (owner, operator) (Some auth_tokens) operators
+
+let remove_operator
+  (operators : operators)
+  (owner : address)
+  (operator : operator)
+  (token_id : nat)
+: operators =
+  if owner = operator
+  then operators
+  (* assert_authorisation always allow the owner so this case is not relevant *)
+
+  else
+    let () = Assertions.assert_update_permission owner in
+    let auth_tokens =
+      match Big_map.find_opt (owner, operator) operators with
+        None -> None
+      | Some (ts) ->
+          let ts = Set.remove token_id ts in
+          [@no_mutation]
+          let is_empty = Set.size ts = 0n in
+          if is_empty then None else Some (ts) in
+    Big_map.update (owner, operator) auth_tokens operators
+
+//module Ledger = struct
+
+let is_owner_of (ledger : ledger) (token_id : nat) (owner : address) : bool =
+  let current_owner = Option.unopt (Big_map.find_opt token_id ledger) in
+  current_owner = owner
+
+let assert_owner_of (ledger : ledger) (token_id : nat) (owner : address)
+: unit =
+  assert_with_error (is_owner_of ledger token_id owner) Errors.ins_balance
+
+let transfer_token_from_user_to_user
+  (ledger : ledger)
+  (token_id : nat)
+  (from_ : address)
+  (to_ : address)
+: ledger =
+  let () = assert_owner_of ledger token_id from_ in
+  let ledger = Big_map.update token_id (Some to_) ledger in
+  ledger
+
+//module Storage = struct
+
+let is_owner_of (type a) (s : a storage) (owner : address) (token_id : nat) : bool =
+  is_owner_of s.ledger token_id owner
+
+let set_ledger (type a) (s : a storage) (ledger : ledger) = {s with ledger = ledger}
+
+let get_operators (type a) (s : a storage) = s.operators
+
+let set_operators (type a) (s : a storage) (operators : operators) =
+  {s with operators = operators}
+
+let get_balance (type a) (s : a storage) (owner : address) (token_id : nat) : nat =
+  let () = Assertions.assert_token_exist s.token_metadata token_id in
+  if is_owner_of s owner token_id then 1n else 0n
+
+let transfer (type a) (t : TZIP12.transfer) (s : a storage) : a ret =
+  (* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se *)
+
+  let process_atomic_transfer
+    (from_ : address)
+    (ledger, t : ledger * TZIP12.atomic_trans) =
+    let {
+     to_;
+     token_id;
+     amount = _
+    } = t in
+    let () = Assertions.assert_token_exist s.token_metadata token_id in
+    let () = assert_authorisation s.operators from_ token_id in
+    let ledger = transfer_token_from_user_to_user ledger token_id from_ to_ in
+    ledger in
+  let process_single_transfer (ledger, t : ledger * TZIP12.transfer_from) =
+    let {
+     from_;
+     txs
+    } = t in
+    let ledger = List.fold_left (process_atomic_transfer from_) ledger txs in
+    ledger in
+  let ledger = List.fold_left process_single_transfer s.ledger t in
+  let s = set_ledger s ledger in
+  ([] : operation list), s
+
+let balance_of (type a) (b : TZIP12.balance_of) (s : a storage) : a ret =
+  let {
+   requests;
+   callback
+  } = b in
+  let get_balance_info (request : TZIP12.request) : TZIP12.callback =
+    let {
+     owner;
+     token_id
+    } = request in
+    let balance_ = get_balance s owner token_id in
+    {
+     request = request;
+     balance = balance_
+    } in
+  let callback_param = List.map get_balance_info requests in
+  let operation = Tezos.transaction (Main callback_param) 0mutez callback in
+  ([operation] : operation list), s
+
+let update_operators (type a) (updates : TZIP12.update_operators) (s : a storage) : a ret =
+  let update_operator (operators, update : operators * TZIP12.unit_update) =
+    match update with
+      Add_operator
+        {
+         owner = owner;
+         operator = operator;
+         token_id = token_id
+        } -> add_operator operators owner operator token_id
+    | Remove_operator
+        {
+         owner = owner;
+         operator = operator;
+         token_id = token_id
+        } -> remove_operator operators owner operator token_id in
+  let operators = get_operators s in
+  let operators = List.fold_left update_operator operators updates in
+  let s = set_operators s operators in
+  ([] : operation list), s
+
+let get_balance (type a) (p : address * nat) (s : a storage) =
+  let (owner, token_id) = p in
+  let balance_ = get_balance s owner token_id in
+  balance_
+
+let total_supply (type a) (token_id : nat) (s : a storage) =
+  let () = Assertions.assert_token_exist s.token_metadata token_id in
+  1n
+
+let all_tokens (type a) (() : unit) (_s : a storage) : nat set =
+  failwith Errors.not_available
+
+let is_operator (type a) (op : TZIP12.operator) (s : a storage) : bool =
+  let authorized =
+    match Big_map.find_opt (op.owner, op.operator) s.operators with
+      Some (opSet) -> opSet
+    | None -> Set.empty in
+  Set.size authorized > 0n || op.owner = op.operator
+
+let token_metadata (type a) (p : nat) (s : a storage) : TZIP12.tokenMetadataData =
+  match Big_map.find_opt p s.token_metadata with
+    Some (data) -> data
+  | None () -> failwith Errors.undefined_token
+
+

--- a/lib/fa2/nft/nft.impl.jsligo
+++ b/lib/fa2/nft/nft.impl.jsligo
@@ -1,282 +1,70 @@
 #import "../common/assertions.jsligo" "Assertions"
-
 #import "../common/errors.mligo" "Errors"
-
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
-
-#import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
-
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
+#import "./extendable_nft.impl.jsligo" "NFTExtendable"
 
-export namespace NFTExtendable {
-   export type ledger = big_map<nat, address>;
-   export type operator = address;
-   export type operators = big_map<[address, operator], set<nat>>; //[owner,operator]
+export type ledger = NFTExtendable.ledger;
+export type operator = NFTExtendable.operator;
+export type operators = NFTExtendable.operators;
+export type storage = {
+  ledger : ledger,
+  operators : operators,
+  token_metadata : TZIP12.tokenMetadata,
+  metadata : TZIP16.metadata,
+}
+type ret = [list<operation>, storage];
 
-   export type storage<T> = {
-      ledger: ledger,
-      operators: operators,
-      token_metadata: TZIP12.tokenMetadata,
-      metadata: TZIP16.metadata,
-      extension: T
-   };
-   type ret<T> = [list<operation>, storage<T>];
-   //** LIGOFA_NFT
-
-   export const assert_authorisation = (
-      operators: operators,
-      from_: address,
-      token_id: nat
-   ): unit => {
-      const sender_ = (Tezos.get_sender());
-      if (sender_ != from_) {
-         const authorized =
-            match((Big_map.find_opt([from_, sender_], operators))) {
-               when (Some(a)):
-                  a
-               when (None()):
-                  Set.empty
-            };
-         if (! (Set.mem(token_id, authorized))) {
-            return failwith(Errors.not_operator)
-         }
-      } else {
-         return unit
-      }
-   };
-   export const add_operator = (
-      operators: operators,
-      owner: address,
-      operator: address,
-      token_id: nat
-   ): operators => {
-      if (owner == operator) {
-         return operators
-      // assert_authorisation always allow the owner so this case is not relevant
-
-      } else {
-         Assertions.assert_update_permission(owner);
-         let auth_tokens =
-            match(Big_map.find_opt([owner, operator], operators)) {
-               when (Some(ts)):
-                  ts
-               when (None()):
-                  Set.empty
-            };
-         auth_tokens = Set.add(token_id, auth_tokens);
-         return Big_map.update([owner, operator], Some(auth_tokens), operators)
-      }
-   };
-   export const remove_operator = (
-      operators: operators,
-      owner: address,
-      operator: address,
-      token_id: nat
-   ): operators => {
-      if (owner == operator) {
-         return operators
-      // assert_authorisation always allow the owner so this case is not relevant
-
-      } else {
-         Assertions.assert_update_permission(owner);
-         const auth_tokens: option<set<nat>> =
-            match(Big_map.find_opt([owner, operator], operators)) {
-               when (Some(ts)):
-                  do {
-                     const toks = Set.remove(token_id, ts);
-                     if (Set.cardinal(toks) == 0n) {
-                        return None()
-                     } else {
-                        return Some(toks)
-                     }
-                  }
-               when (None()):
-                  None()
-            };
-         return Big_map.update([owner, operator], auth_tokens, operators)
-      }
-   }
-   //  ledger
-
-   export const is_owner_of = (ledger: ledger, token_id: nat, owner: address): bool => {
-      const current_owner = Option.unopt(Big_map.find_opt(token_id, ledger));
-      return (current_owner == owner)
-   };
-   export const assert_owner_of = (
-      ledger: ledger,
-      token_id: nat,
-      owner: address
-   ): unit =>
-      assert_with_error(
-         is_owner_of(ledger, token_id, owner),
-         Errors.ins_balance
-      );
-   export const transfer_token_from_user_to_user = (
-      ledger: ledger,
-      token_id: nat,
-      from_: address,
-      to_: address
-   ): ledger => {
-      assert_owner_of(ledger, token_id, from_);
-      return Big_map.update(token_id, Some(to_), ledger)
-   }
-
-   export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
-      ({ ...s, ledger: ledger });
-   export const get_operators = <T>(s: storage<T>): operators => s.operators;
-   export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
-      ({ ...s, operators: operators })
-
-   //** TZIP12Interface.FA2
-   //  operators
-   /**
-* Check if the intented transfer is sent from the same sender as from field, otherwise check if the sender is part of the operator authorized to receive this token
-* @param operators :  operator bigmap
-* @param from_ : transfer from address
-* @param token_id : token_id to test
-*/
-
-   export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
-      const process_atomic_transfer = (from_: address) =>
-         ([ledger, t]: [ledger, TZIP12.atomic_trans]): ledger => {
-            const { to_, token_id, amount } = t;
-            ignore(amount);
-            Assertions.assert_token_exist(s.token_metadata, token_id);
-            assert_authorisation(s.operators, from_, token_id);
-            return transfer_token_from_user_to_user(
-               ledger,
-               token_id,
-               from_,
-               to_
-            )
-         };
-      const process_single_transfer = (
-         [ledger, t]: [ledger, TZIP12.transfer_from]
-      ): ledger => {
-         const { from_, txs } = t;
-         return List.fold_left(process_atomic_transfer(from_), ledger, txs)
-      };
-      const ledger = List.fold_left(process_single_transfer, s.ledger, t);
-      const store = set_ledger([s, ledger]);
-      return [list([]), store]
-   };
-
-   export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
-      const { requests, callback } = b;
-      const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
-         const { owner, token_id } = request;
-         Assertions.assert_token_exist(s.token_metadata, token_id);
-         let balance_ = 0 as nat;
-         if (is_owner_of(s.ledger, token_id, owner)) balance_ = 1 as nat;
-         return ({ request: request, balance: balance_ })
-      };
-      const callback_param = List.map(get_balance_info, requests);
-      const operation =
-         Tezos.transaction(Main(callback_param), 0mutez, callback);
-      return [list([operation]), s]
-   };
-
-   export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
-      const update_operator = (
-         [operators, update]: [operators, TZIP12.unit_update]
-      ): operators =>
-         match(update) {
-            when (Add_operator(operator)):
-               add_operator(
-                  operators,
-                  operator.owner,
-                  operator.operator,
-                  operator.token_id
-               )
-            when (Remove_operator(operator)):
-               remove_operator(
-                  operators,
-                  operator.owner,
-                  operator.operator,
-                  operator.token_id
-               )
-         };
-      let operators = get_operators(s);
-      operators = List.fold_left(update_operator, operators, updates);
-      const store = set_operators([s, operators]);
-      return [list([]), store]
-   };
-
-   export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
-      const [owner, token_id] = p;
-      Assertions.assert_token_exist(s.token_metadata, token_id);
-      if (is_owner_of(s.ledger, token_id, owner)) {
-         return 1n
-      } else {
-         return 0n
-      }
-   };
-
-   export const total_supply = <T>(token_id: nat, s: storage<T>): nat => {
-      Assertions.assert_token_exist(s.token_metadata, token_id);
-      return 1n
-   };
-
-   export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
-      failwith(Errors.not_available);
-
-   export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
-      const authorized =
-         match(Big_map.find_opt([op.owner, op.operator], s.operators)) {
-            when (Some(a)):
-               a
-            when (None()):
-               Set.empty
-         };
-      return (Set.mem(op.token_id, authorized) || op.owner == op.operator)
-   };
-
-   export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
-      return match(Big_map.find_opt(p, s.token_metadata)) {
-         when (Some(data)):
-            data
-         when (None()):
-            failwith(Errors.undefined_token)
-      }
-   }
+@inline
+const lift = (s: storage): NFTExtendable.storage<unit> => {
+  return {
+    extension: unit,
+    ledger: s.ledger,
+    operators: s.operators,
+    token_metadata: s.token_metadata,
+    metadata: s.metadata
+  };
 }
 
-export namespace NFT implements TZIP12Interface.FA2 {
-  export type ledger = NFTExtendable.ledger;
-  export type operator = NFTExtendable.operator;
-  export type operators = NFTExtendable.operators;
-  export type storage = NFTExtendable.storage<unit>;
-  type ret = [list<operation>, storage];
-
-  @entry
-  const transfer = (t: TZIP12.transfer, s: storage): ret =>
-    NFTExtendable.transfer(t, s)
-
-  @entry
-  const balance_of = (b: TZIP12.balance_of, s: storage): ret =>
-    NFTExtendable.balance_of(b, s)
-
-  @entry
-  const update_operators = (updates: TZIP12.update_operators, s: storage): ret =>
-    NFTExtendable.update_operators(updates, s)
-
-  @view
-  const get_balance = (p: [address, nat], s: storage): nat =>
-    NFTExtendable.get_balance(p, s)
-
-  @view
-  const total_supply = (token_id: nat, s: storage): nat =>
-    NFTExtendable.total_supply(token_id, s)
-
-  @view
-  const all_tokens = (_: unit, s: storage): set<nat> =>
-    NFTExtendable.all_tokens(unit, s)
-
-  @view
-  const is_operator = (op: TZIP12.operator, s: storage): bool =>
-    NFTExtendable.is_operator(op, s)
-
-  @view
-  const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData =>
-    NFTExtendable.token_metadata(p, s)
+@inline
+const unlift = ([ops, s]: [list<operation>, NFTExtendable.storage<unit>]): ret => {
+  let storage = {
+    ledger: s.ledger,
+    operators: s.operators,
+    token_metadata: s.token_metadata,
+    metadata: s.metadata
+  };
+  return [ops, storage];
 }
+
+@entry
+const transfer = (t: TZIP12.transfer, s: storage): ret =>
+  unlift(NFTExtendable.transfer(t, lift(s)))
+
+@entry
+const balance_of = (b: TZIP12.balance_of, s: storage): ret =>
+  unlift(NFTExtendable.balance_of(b, lift(s)))
+
+@entry
+const update_operators = (updates: TZIP12.update_operators, s: storage): ret =>
+  unlift(NFTExtendable.update_operators(updates, lift(s)))
+
+@view
+const get_balance = (p: [address, nat], s: storage): nat =>
+  NFTExtendable.get_balance(p, lift(s))
+
+@view
+const total_supply = (token_id: nat, s: storage): nat =>
+  NFTExtendable.total_supply(token_id, lift(s))
+
+@view
+const all_tokens = (_: unit, s: storage): set<nat> =>
+  NFTExtendable.all_tokens(unit, lift(s))
+
+@view
+const is_operator = (op: TZIP12.operator, s: storage): bool =>
+  NFTExtendable.is_operator(op, lift(s))
+
+@view
+const token_metadata = (p: nat, s: storage): TZIP12.tokenMetadataData =>
+  NFTExtendable.token_metadata(p, lift(s))

--- a/lib/fa2/nft/nft.impl.mligo
+++ b/lib/fa2/nft/nft.impl.mligo
@@ -3,260 +3,73 @@
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
 #import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
-module NFTExtendable = struct
-  type ledger = (nat, address) big_map
+#import "./extendable_nft.impl.mligo" "NFTExtendable"
 
-  type operator = address
+type ledger = NFTExtendable.ledger
 
-  type operators = ((address * operator), nat set) big_map
+type operator = NFTExtendable.operator
 
-  type 'a storage =
-    {
-     ledger : ledger;
-     operators : operators;
-     token_metadata : TZIP12.tokenMetadata;
-     metadata : TZIP16.metadata;
-     extension : 'a
-    }
+type operators = NFTExtendable.operators
 
-  type 'a ret = operation list * 'a storage
+type storage = {
+   ledger : ledger;
+   operators : operators;
+   token_metadata : TZIP12.tokenMetadata;
+   metadata : TZIP16.metadata;
+}
 
-  // Operators
+type ret = operation list * storage
 
-  let assert_authorisation
-    (operators : operators)
-    (from_ : address)
-    (token_id : nat)
-  : unit =
-    let sender_ = (Tezos.get_sender ()) in
-    if (sender_ = from_)
-    then ()
-    else
-      let authorized =
-        match Big_map.find_opt (from_, sender_) operators with
-          Some (a) -> a
-        | None -> Set.empty in
-      if Set.mem token_id authorized then () else failwith Errors.not_operator
+[@inline]
+let lift (s : storage) : unit NFTExtendable.storage =
+  {
+    ledger = s.ledger;
+    operators = s.operators;
+    token_metadata = s.token_metadata;
+    metadata = s.metadata;
+    extension = ();
+  }
 
-  let is_operator
-    (operators, owner, operator, token_id
-     : (operators * address * address * nat))
-  : bool =
-    let authorized =
-      match Big_map.find_opt (owner, operator) operators with
-        Some (a) -> a
-      | None -> Set.empty in
-    (owner = operator || Set.mem token_id authorized)
+[@inline]
+let unlift (ret : operation list * unit NFTExtendable.storage) : ret =
+  let ops, s = ret in
+  ops,
+  {
+    ledger = s.ledger;
+    operators = s.operators;
+    token_metadata = s.token_metadata;
+    metadata = s.metadata;
+  }
 
-  let add_operator
-    (operators : operators)
-    (owner : address)
-    (operator : operator)
-    (token_id : nat)
-  : operators =
-    if owner = operator
-    then operators
-    (* assert_authorisation always allow the owner so this case is not relevant *)
+[@entry]
+let transfer (t : TZIP12.transfer) (s : storage) : ret =
+  unlift (NFTExtendable.transfer t (lift s))
 
-    else
-      let () = Assertions.assert_update_permission owner in
-      let auth_tokens =
-        match Big_map.find_opt (owner, operator) operators with
-          Some (ts) -> ts
-        | None -> Set.empty in
-      let auth_tokens = Set.add token_id auth_tokens in
-      Big_map.update (owner, operator) (Some auth_tokens) operators
+[@entry]
+let balance_of (b : TZIP12.balance_of) (s : storage) : ret =
+  unlift (NFTExtendable.balance_of b (lift s))
 
-  let remove_operator
-    (operators : operators)
-    (owner : address)
-    (operator : operator)
-    (token_id : nat)
-  : operators =
-    if owner = operator
-    then operators
-    (* assert_authorisation always allow the owner so this case is not relevant *)
+[@entry]
+let update_operators (updates : TZIP12.update_operators) (s : storage) : ret =
+  unlift (NFTExtendable.update_operators updates (lift s))
 
-    else
-      let () = Assertions.assert_update_permission owner in
-      let auth_tokens =
-        match Big_map.find_opt (owner, operator) operators with
-          None -> None
-        | Some (ts) ->
-            let ts = Set.remove token_id ts in
-            [@no_mutation]
-            let is_empty = Set.size ts = 0n in
-            if is_empty then None else Some (ts) in
-      Big_map.update (owner, operator) auth_tokens operators
+[@view]
+let get_balance (p : (address * nat)) (s : storage) : nat =
+  NFTExtendable.get_balance p (lift s)
 
-  //module Ledger = struct
+(* FIXME Not sure why we are implementing the two following views *)
+[@view]
+let total_supply (token_id : nat) (s : storage) : nat =
+  NFTExtendable.total_supply token_id (lift s)
 
-  let is_owner_of (ledger : ledger) (token_id : nat) (owner : address) : bool =
-    let current_owner = Option.unopt (Big_map.find_opt token_id ledger) in
-    current_owner = owner
+[@view]
+let all_tokens (_ : unit) (s : storage) : nat set =
+  NFTExtendable.all_tokens () (lift s)
 
-  let assert_owner_of (ledger : ledger) (token_id : nat) (owner : address)
-  : unit =
-    assert_with_error (is_owner_of ledger token_id owner) Errors.ins_balance
+[@view]
+let is_operator (op : TZIP12.operator) (s : storage) : bool =
+  NFTExtendable.is_operator op (lift s)
 
-  let transfer_token_from_user_to_user
-    (ledger : ledger)
-    (token_id : nat)
-    (from_ : address)
-    (to_ : address)
-  : ledger =
-    let () = assert_owner_of ledger token_id from_ in
-    let ledger = Big_map.update token_id (Some to_) ledger in
-    ledger
-
-  //module Storage = struct
-
-  let is_owner_of (type a) (s : a storage) (owner : address) (token_id : nat) : bool =
-    is_owner_of s.ledger token_id owner
-
-  let set_ledger (type a) (s : a storage) (ledger : ledger) = {s with ledger = ledger}
-
-  let get_operators (type a) (s : a storage) = s.operators
-
-  let set_operators (type a) (s : a storage) (operators : operators) =
-    {s with operators = operators}
-
-  let get_balance (type a) (s : a storage) (owner : address) (token_id : nat) : nat =
-    let () = Assertions.assert_token_exist s.token_metadata token_id in
-    if is_owner_of s owner token_id then 1n else 0n
-
-  let transfer (type a) (t : TZIP12.transfer) (s : a storage) : a ret =
-    (* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se *)
-
-    let process_atomic_transfer
-      (from_ : address)
-      (ledger, t : ledger * TZIP12.atomic_trans) =
-      let {
-       to_;
-       token_id;
-       amount = _
-      } = t in
-      let () = Assertions.assert_token_exist s.token_metadata token_id in
-      let () = assert_authorisation s.operators from_ token_id in
-      let ledger = transfer_token_from_user_to_user ledger token_id from_ to_ in
-      ledger in
-    let process_single_transfer (ledger, t : ledger * TZIP12.transfer_from) =
-      let {
-       from_;
-       txs
-      } = t in
-      let ledger = List.fold_left (process_atomic_transfer from_) ledger txs in
-      ledger in
-    let ledger = List.fold_left process_single_transfer s.ledger t in
-    let s = set_ledger s ledger in
-    ([] : operation list), s
-
-  let balance_of (type a) (b : TZIP12.balance_of) (s : a storage) : a ret =
-    let {
-     requests;
-     callback
-    } = b in
-    let get_balance_info (request : TZIP12.request) : TZIP12.callback =
-      let {
-       owner;
-       token_id
-      } = request in
-      let balance_ = get_balance s owner token_id in
-      {
-       request = request;
-       balance = balance_
-      } in
-    let callback_param = List.map get_balance_info requests in
-    let operation = Tezos.transaction (Main callback_param) 0mutez callback in
-    ([operation] : operation list), s
-
-  let update_operators (type a) (updates : TZIP12.update_operators) (s : a storage) : a ret =
-    let update_operator (operators, update : operators * TZIP12.unit_update) =
-      match update with
-        Add_operator
-          {
-           owner = owner;
-           operator = operator;
-           token_id = token_id
-          } -> add_operator operators owner operator token_id
-      | Remove_operator
-          {
-           owner = owner;
-           operator = operator;
-           token_id = token_id
-          } -> remove_operator operators owner operator token_id in
-    let operators = get_operators s in
-    let operators = List.fold_left update_operator operators updates in
-    let s = set_operators s operators in
-    ([] : operation list), s
-
-  let get_balance (type a) (p : address * nat) (s : a storage) =
-    let (owner, token_id) = p in
-    let balance_ = get_balance s owner token_id in
-    balance_
-
-  let total_supply (type a) (token_id : nat) (s : a storage) =
-    let () = Assertions.assert_token_exist s.token_metadata token_id in
-    1n
-
-  let all_tokens (type a) (() : unit) (_s : a storage) : nat set =
-    failwith Errors.not_available
-
-  let is_operator (type a) (op : TZIP12.operator) (s : a storage) : bool =
-    let authorized =
-      match Big_map.find_opt (op.owner, op.operator) s.operators with
-        Some (opSet) -> opSet
-      | None -> Set.empty in
-    Set.size authorized > 0n || op.owner = op.operator
-
-  let token_metadata (type a) (p : nat) (s : a storage) : TZIP12.tokenMetadataData =
-    match Big_map.find_opt p s.token_metadata with
-      Some (data) -> data
-    | None () -> failwith Errors.undefined_token
-
-end
-
-module NFT = struct
-  type ledger = NFTExtendable.ledger
-
-  type operator = NFTExtendable.operator
-
-  type operators = NFTExtendable.operators
-
-  type storage = unit NFTExtendable.storage
-
-  type ret = unit NFTExtendable.ret
-
-  [@entry]
-  let transfer (t : TZIP12.transfer) (s : storage) : ret =
-    NFTExtendable.transfer t s
-
-  [@entry]
-  let balance_of (b : TZIP12.balance_of) (s : storage) : ret =
-    NFTExtendable.balance_of b s
-
-  [@entry]
-  let update_operators (updates : TZIP12.update_operators) (s : storage) : ret =
-    NFTExtendable.update_operators updates s
-
-  [@view]
-  let get_balance (p : (address * nat)) (s : storage) : nat =
-    NFTExtendable.get_balance p s
-
-  (* FIXME Not sure why we are implementing the two following views *)
-  [@view]
-  let total_supply (token_id : nat) (s : storage) : nat =
-    NFTExtendable.total_supply token_id s
-
-  [@view]
-  let all_tokens (_ : unit) (s : storage) : nat set =
-    NFTExtendable.all_tokens () s
-
-  [@view]
-  let is_operator (op : TZIP12.operator) (s : storage) : bool =
-    NFTExtendable.is_operator op s
-
-  [@view]
-  let token_metadata (p : nat) (s : storage) : TZIP12.tokenMetadataData =
-    NFTExtendable.token_metadata p s
-end
+[@view]
+let token_metadata (p : nat) (s : storage) : TZIP12.tokenMetadataData =
+  NFTExtendable.token_metadata p (lift s)

--- a/lib/fa2/nft/nft.impl.mligo
+++ b/lib/fa2/nft/nft.impl.mligo
@@ -57,7 +57,6 @@ let update_operators (updates : TZIP12.update_operators) (s : storage) : ret =
 let get_balance (p : (address * nat)) (s : storage) : nat =
   NFTExtendable.get_balance p (lift s)
 
-(* FIXME Not sure why we are implementing the two following views *)
 [@view]
 let total_supply (token_id : nat) (s : storage) : nat =
   NFTExtendable.total_supply token_id (lift s)

--- a/lib/main.jsligo
+++ b/lib/main.jsligo
@@ -1,0 +1,11 @@
+// An implementaion of FA2 Interface (TZIP-12) for NFT
+#import "./fa2/nft/nft.impl.jsligo" "NFT"
+#import "./fa2/nft/extendable_nft.impl.jsligo" "NFTExtendable"
+
+// An implementaion of FA2 Interface (TZIP-12) for a Single Asset Token
+#import "./fa2/asset/single_asset.impl.jsligo" "SingleAsset"
+#import "./fa2/asset/extendable_single_asset.impl.jsligo" "SingleAssetExtendable"
+
+// An implementaion of FA2 Interface (TZIP-12) for a Multi Asset Token
+#import "./fa2/asset/multi_asset.impl.jsligo" "MultiAsset"
+#import "./fa2/asset/extendable_multi_asset.impl.jsligo" "MultiAssetExtendable"

--- a/lib/main.mligo
+++ b/lib/main.mligo
@@ -4,6 +4,8 @@
 
 (* An implementaion of FA2 Interface (TZIP-12) for a Single Asset Token *)
 #import "./fa2/asset/single_asset.impl.mligo" "SingleAsset"
+#import "./fa2/asset/extendable_single_asset.impl.mligo" "SingleAssetExtendable"
 
 (* An implementaion of FA2 Interface (TZIP-12) for a Multi Asset Token *)
 #import "./fa2/asset/multi_asset.impl.mligo" "MultiAsset"
+#import "./fa2/asset/extendable_multi_asset.impl.mligo" "MultiAssetExtendable"

--- a/lib/main.mligo
+++ b/lib/main.mligo
@@ -1,9 +1,9 @@
 (* An implementaion of FA2 Interface (TZIP-12) for NFT *)
 #import "./fa2/nft/nft.impl.mligo" "NFT"
+#import "./fa2/nft/extendable_nft.impl.mligo" "NFTExtendable"
 
 (* An implementaion of FA2 Interface (TZIP-12) for a Single Asset Token *)
 #import "./fa2/asset/single_asset.impl.mligo" "SingleAsset"
 
 (* An implementaion of FA2 Interface (TZIP-12) for a Multi Asset Token *)
 #import "./fa2/asset/multi_asset.impl.mligo" "MultiAsset"
-

--- a/ligo.json
+++ b/ligo.json
@@ -1,6 +1,6 @@
 {
   "name": "@ligo/fa",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "FA2 interface and types compliant with TZIP12. The library is also providing 3 Ligo contract implementations for nft, single asset & multi asset contracts",
   "directories": {
     "lib": "lib",

--- a/test/fa2/multi_asset.test.mligo
+++ b/test/fa2/multi_asset.test.mligo
@@ -76,19 +76,18 @@ let get_initial_storage (a, b, c : nat * nat * nat) =
 ]  in
 
 
-  let initial_storage : FA2_multi_asset.MultiAsset.storage  = {
+  let initial_storage : FA2_multi_asset.storage  = {
     ledger         = ledger;
     token_metadata = token_metadata;
     operators      = operators;
     metadata       = metadata;
-    extension      = ();
   } in
 
   initial_storage, owners, ops
 
 
 let assert_balances
-  (contract_address : (FA2_multi_asset.MultiAsset parameter_of, FA2_multi_asset.MultiAsset.storage) typed_address )
+  (contract_address : (FA2_multi_asset parameter_of, FA2_multi_asset.storage) typed_address )
   (a, b, c : (address * nat * nat) * (address * nat * nat) * (address * nat * nat)) =
   let (owner1, token_id_1, balance1) = a in
   let (owner2, token_id_2, balance2) = b in
@@ -124,7 +123,7 @@ let test_atomic_tansfer_success =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 2n, 8n), (owner2, 2n, 12n), (owner3, 3n, 10n)) in
@@ -143,7 +142,7 @@ let test_transfer_token_undefined =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -162,7 +161,7 @@ let test_atomic_transfer_failure_not_operator =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -181,7 +180,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -202,7 +201,7 @@ let test_atomic_tansfer_success_zero_amount_and_self_transfer =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 1n, 10n), (owner2, 2n, 10n), (owner3, 3n, 10n)) in
@@ -219,7 +218,7 @@ let test_transfer_failure_transitive_operators =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -240,7 +239,7 @@ let test_empty_transfer_and_balance_of =
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -264,7 +263,7 @@ let test_balance_of_token_undefines =
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -292,7 +291,7 @@ let test_balance_of_requests_with_duplicates =
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -318,7 +317,7 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
       callback = callback_contract;
     } : FA2_multi_asset.TZIP12.balance_of) in
 
-    let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+    let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
     let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -335,7 +334,7 @@ let test_update_operator_remove_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
 
   let () = Test.set_source owner1 in
@@ -366,7 +365,7 @@ let test_update_operator_add_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
 
   let () = Test.set_source owner1 in

--- a/test/fa2/multi_asset_jsligo.test.mligo
+++ b/test/fa2/multi_asset_jsligo.test.mligo
@@ -76,19 +76,18 @@ let get_initial_storage (a, b, c : nat * nat * nat) =
 }|}]);
 ]  in
 
-  let initial_storage : FA2_multi_asset.MultiAsset.storage = {
+  let initial_storage : FA2_multi_asset.storage = {
     ledger         = ledger;
     token_metadata = token_metadata;
     operators      = operators;
     metadata       = metadata;
-    extension      = ();
   } in
 
   initial_storage, owners, ops
 
 
 let assert_balances
-  (contract_address : (FA2_multi_asset.MultiAsset parameter_of, FA2_multi_asset.MultiAsset.storage) typed_address )
+  (contract_address : (FA2_multi_asset parameter_of, FA2_multi_asset.storage) typed_address )
   (a, b, c : (address * nat * nat) * (address * nat * nat) * (address * nat * nat)) =
   let (owner1, token_id_1, balance1) = a in
   let (owner2, token_id_2, balance2) = b in
@@ -124,7 +123,7 @@ let test_atomic_tansfer_success =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 2n, 8n), (owner2, 2n, 12n), (owner3, 3n, 10n)) in
@@ -143,7 +142,7 @@ let test_transfer_token_undefined =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -162,7 +161,7 @@ let test_atomic_transfer_failure_not_operator =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -181,7 +180,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -202,7 +201,7 @@ let test_atomic_tansfer_success_zero_amount_and_self_transfer =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 1n, 10n), (owner2, 2n, 10n), (owner3, 3n, 10n)) in
@@ -219,7 +218,7 @@ let test_transfer_failure_transitive_operators =
   ] : FA2_multi_asset.TZIP12.transfer)
   in
   let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -240,7 +239,7 @@ let test_empty_transfer_and_balance_of =
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -264,7 +263,7 @@ let test_balance_of_token_undefines =
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -292,7 +291,7 @@ let test_balance_of_requests_with_duplicates =
     callback = callback_contract;
   } : FA2_multi_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -318,7 +317,7 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
       callback = callback_contract;
     } : FA2_multi_asset.TZIP12.balance_of) in
 
-    let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+    let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
     let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -335,7 +334,7 @@ let test_update_operator_remove_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
 
   let () = Test.set_source owner1 in
@@ -366,7 +365,7 @@ let test_update_operator_add_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let _owner3= List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_multi_asset.MultiAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_multi_asset) initial_storage 0tez in
 
 
   let () = Test.set_source owner1 in

--- a/test/fa2/nft/nft.test.mligo
+++ b/test/fa2/nft/nft.test.mligo
@@ -6,7 +6,7 @@
 (* Tests for FA2 multi asset contract *)
 
 
-type fa2_nft = (FA2_NFT.NFT parameter_of, FA2_NFT.NFT.storage) module_contract
+type fa2_nft = (FA2_NFT parameter_of, FA2_NFT.storage) module_contract
 
 
 (* Transfer *)
@@ -24,12 +24,12 @@ let _test_atomic_tansfer_operator_success (contract: fa2_nft) =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate contract initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
 
-let test_atomic_tansfer_operator_success = _test_atomic_tansfer_operator_success (contract_of FA2_NFT.NFT)
+let test_atomic_tansfer_operator_success = _test_atomic_tansfer_operator_success (contract_of FA2_NFT)
 
 
 (* 1.1. transfer successful owner *)
@@ -44,12 +44,12 @@ let _test_atomic_tansfer_owner_success (contract: fa2_nft) =
   in
   let () = Test.set_source owner1 in
   let orig = Test.originate contract  initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
 
-let test_atomic_tansfer_owner_success = _test_atomic_tansfer_owner_success (contract_of FA2_NFT.NFT)
+let test_atomic_tansfer_owner_success = _test_atomic_tansfer_owner_success (contract_of FA2_NFT)
 
 
 (* 2. transfer failure token undefined *)
@@ -64,11 +64,11 @@ let _test_transfer_token_undefined (contract: fa2_nft) =
   in
   let () = Test.set_source op1 in
   let orig = Test.originate contract  initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.undefined_token
 
-let test_transfer_token_undefined = _test_transfer_token_undefined (contract_of FA2_NFT.NFT)
+let test_transfer_token_undefined = _test_transfer_token_undefined (contract_of FA2_NFT)
 
 
 (* 3. transfer failure incorrect operator *)
@@ -83,12 +83,12 @@ let _test_atomic_transfer_failure_not_operator (contract: fa2_nft) =
   in
   let () = Test.set_source op2 in
   let orig = Test.originate contract initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.not_operator
 let test_atomic_transfer_failure_not_operator
 
-  = _test_atomic_transfer_failure_not_operator (contract_of FA2_NFT.NFT)
+  = _test_atomic_transfer_failure_not_operator (contract_of FA2_NFT)
 
 (* 4. self transfer *)
 let _test_atomic_tansfer_success_zero_amount_and_self_transfer (contract: fa2_nft) =
@@ -103,13 +103,13 @@ let _test_atomic_tansfer_success_zero_amount_and_self_transfer (contract: fa2_nf
   in
 
   let orig = Test.originate contract initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = TestHelpers.assert_balances orig.addr ((owner1, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
 let test_atomic_tansfer_success_zero_amount_and_self_transfer =
 
-  _test_atomic_tansfer_success_zero_amount_and_self_transfer (contract_of FA2_NFT.NFT)
+  _test_atomic_tansfer_success_zero_amount_and_self_transfer (contract_of FA2_NFT)
 
 
 (* 5. transfer failure transitive operators *)
@@ -124,12 +124,12 @@ let _test_transfer_failure_transitive_operators (contract: fa2_nft) =
   in
   let () = Test.set_source op3 in
   let orig = Test.originate contract initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.not_operator
 let test_transfer_failure_transitive_operators =
 
-  _test_transfer_failure_transitive_operators (contract_of FA2_NFT.NFT)
+  _test_transfer_failure_transitive_operators (contract_of FA2_NFT)
 
 
 (* Balance of *)
@@ -146,13 +146,13 @@ let _test_empty_transfer_and_balance_of (contract: fa2_nft) =
   } : FA2_NFT.TZIP12.balance_of) in
 
   let orig = Test.originate contract initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
   Test.assert (callback_storage = ([] : nat list))
 
-let test_empty_transfer_and_balance_of = _test_empty_transfer_and_balance_of (contract_of FA2_NFT.NFT)
+let test_empty_transfer_and_balance_of = _test_empty_transfer_and_balance_of (contract_of FA2_NFT)
 
 
 (* 7. balance of failure token undefined *)
@@ -174,11 +174,11 @@ let _test_balance_of_token_undefines (contract: fa2_nft) =
   } : FA2_NFT.TZIP12.balance_of) in
 
   let orig = Test.originate contract initial_storage 0tez in
-  
+
   let result = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.undefined_token
 
-let test_balance_of_token_undefines = _test_balance_of_token_undefines (contract_of FA2_NFT.NFT)
+let test_balance_of_token_undefines = _test_balance_of_token_undefines (contract_of FA2_NFT)
 
 
 (* 8. duplicate balance_of requests *)
@@ -200,14 +200,14 @@ let _test_balance_of_requests_with_duplicates (contract: fa2_nft) =
   } : FA2_NFT.TZIP12.balance_of) in
 
   let orig = Test.originate contract initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
   let callback_storage = Test.get_storage orig_callback.addr in
   Test.assert (callback_storage = ([1n; 1n; 1n; 0n]))
 let test_balance_of_requests_with_duplicates
 
-  = _test_balance_of_requests_with_duplicates (contract_of FA2_NFT.NFT)
+  = _test_balance_of_requests_with_duplicates (contract_of FA2_NFT)
 
 
 (* 9. 0 balance if does not hold any tokens (not in ledger) *)
@@ -229,14 +229,14 @@ let _test_balance_of_0_balance_if_address_does_not_hold_tokens (contract: fa2_nf
     } : FA2_NFT.TZIP12.balance_of) in
 
     let orig = Test.originate contract initial_storage 0tez in
-    
+
     let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
     let callback_storage = Test.get_storage orig_callback.addr in
     Test.assert (callback_storage = ([1n; 1n; 0n]))
 let test_balance_of_0_balance_if_address_does_not_hold_tokens =
 
-  _test_balance_of_0_balance_if_address_does_not_hold_tokens (contract_of FA2_NFT.NFT)
+  _test_balance_of_0_balance_if_address_does_not_hold_tokens (contract_of FA2_NFT)
 
 
 (* Update operators *)
@@ -248,7 +248,7 @@ let _test_update_operator_remove_operator_and_transfer (contract: fa2_nft) =
   let owner2 = List_helper.nth_exn 1 owners in
   let op1    = List_helper.nth_exn 0 operators in
   let orig = Test.originate contract initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner1 in
   let _ = Test.transfer_exn orig.addr
@@ -269,7 +269,7 @@ let _test_update_operator_remove_operator_and_transfer (contract: fa2_nft) =
   TestHelpers.assert_error result FA2_NFT.Errors.not_operator
 let test_update_operator_remove_operator_and_transfer =
 
-  _test_update_operator_remove_operator_and_transfer (contract_of FA2_NFT.NFT)
+  _test_update_operator_remove_operator_and_transfer (contract_of FA2_NFT)
 
 
 (* 10.1. Remove operator & do transfer - failure *)
@@ -278,7 +278,7 @@ let _test_update_operator_remove_operator_and_transfer1 (contract: fa2_nft) =
   let owner4 = List_helper.nth_exn 3 owners in
   let op1    = List_helper.nth_exn 0 operators in
   let orig = Test.originate contract initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner4 in
   let _ = Test.transfer_exn orig.addr
@@ -296,7 +296,7 @@ let _test_update_operator_remove_operator_and_transfer1 (contract: fa2_nft) =
   Test.assert (operator_tokens = Set.literal [5n])
 let test_update_operator_remove_operator_and_transfer1 =
 
-  _test_update_operator_remove_operator_and_transfer1 (contract_of FA2_NFT.NFT)
+  _test_update_operator_remove_operator_and_transfer1 (contract_of FA2_NFT)
 
 
 
@@ -307,7 +307,7 @@ let _test_update_operator_add_operator_and_transfer (contract: fa2_nft) =
   let owner2 = List_helper.nth_exn 1 owners in
   let op3    = List_helper.nth_exn 2 operators in
   let orig = Test.originate contract initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner1 in
   let _ = Test.transfer_exn orig.addr
@@ -328,7 +328,7 @@ let _test_update_operator_add_operator_and_transfer (contract: fa2_nft) =
   ()
 let test_update_operator_add_operator_and_transfer =
 
-  _test_update_operator_add_operator_and_transfer (contract_of FA2_NFT.NFT)
+  _test_update_operator_add_operator_and_transfer (contract_of FA2_NFT)
 
 
 (* 11.1. Add operator & do transfer - success *)
@@ -338,7 +338,7 @@ let _test_update_operator_add_operator_and_transfer1 (contract: fa2_nft) =
   let owner4 = List_helper.nth_exn 3 owners in
   let op3    = List_helper.nth_exn 2 operators in
   let orig = Test.originate contract initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner4 in
   let _ = Test.transfer_exn orig.addr
@@ -359,7 +359,7 @@ let _test_update_operator_add_operator_and_transfer1 (contract: fa2_nft) =
   ()
 let test_update_operator_add_operator_and_transfer1 =
 
-  _test_update_operator_add_operator_and_transfer1 (contract_of FA2_NFT.NFT)
+  _test_update_operator_add_operator_and_transfer1 (contract_of FA2_NFT)
 
 
 let _test_only_sender_manage_operators (contract: fa2_nft) =
@@ -368,7 +368,7 @@ let _test_only_sender_manage_operators (contract: fa2_nft) =
   let owner2 = List_helper.nth_exn 1 owners in
   let op3    = List_helper.nth_exn 2 operators in
   let orig = Test.originate contract initial_storage 0tez in
-  
+
 
   let () = Test.set_source owner2 in
   let result = Test.transfer orig.addr
@@ -383,5 +383,5 @@ let _test_only_sender_manage_operators (contract: fa2_nft) =
   TestHelpers.assert_error result FA2_NFT.Errors.only_sender_manage_operators
 
 
-let test_only_sender_manage_operators = _test_only_sender_manage_operators (contract_of FA2_NFT.NFT)
+let test_only_sender_manage_operators = _test_only_sender_manage_operators (contract_of FA2_NFT)
 

--- a/test/fa2/nft/nft_jsligo.test.mligo
+++ b/test/fa2/nft/nft_jsligo.test.mligo
@@ -3,7 +3,7 @@
 #import "../../helpers/list.mligo" "List_helper"
 #import "../../helpers/nft_helpers.mligo" "TestHelpers"
 (* Tests for FA2 multi asset contract *)
-type return = operation list * FA2_NFT.NFT.storage
+type return = operation list * FA2_NFT.storage
 (* Transfer *)
 (* 1. transfer successful *)
 let _test_atomic_tansfer_operator_success () =
@@ -17,8 +17,8 @@ let _test_atomic_tansfer_operator_success () =
   ] : FA2_NFT.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let _ = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
@@ -34,8 +34,8 @@ let _test_atomic_tansfer_owner_success () =
   ] : FA2_NFT.TZIP12.transfer)
   in
   let () = Test.set_source owner1 in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let _ = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
@@ -51,8 +51,8 @@ let _test_transfer_token_undefined () =
   ] : FA2_NFT.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.undefined_token
 let test_transfer_token_undefined = _test_transfer_token_undefined ()
@@ -67,8 +67,8 @@ let _test_atomic_transfer_failure_not_operator () =
   ] : FA2_NFT.TZIP12.transfer)
   in
   let () = Test.set_source op2 in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.not_operator
 let test_atomic_transfer_failure_not_operator
@@ -85,8 +85,8 @@ let _test_atomic_tansfer_success_zero_amount_and_self_transfer () =
   ] : FA2_NFT.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let _ = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   let () = TestHelpers.assert_balances orig.addr ((owner1, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
@@ -103,8 +103,8 @@ let _test_transfer_failure_transitive_operators () =
   ] : FA2_NFT.TZIP12.transfer)
   in
   let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.not_operator
 let test_transfer_failure_transitive_operators =
@@ -119,8 +119,8 @@ let _test_empty_transfer_and_balance_of () =
     requests = ([] : FA2_NFT.TZIP12.request list);
     callback = callback_contract;
   } : FA2_NFT.TZIP12.balance_of) in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let _ = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
   let callback_storage = Test.get_storage orig_callback.addr in
   Test.assert (List.size(callback_storage) = 0n)
@@ -141,8 +141,8 @@ let _test_balance_of_token_undefines () =
     ] : FA2_NFT.TZIP12.request list);
     callback = callback_contract;
   } : FA2_NFT.TZIP12.balance_of) in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let result = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
   TestHelpers.assert_error result FA2_NFT.Errors.undefined_token
 let test_balance_of_token_undefines = _test_balance_of_token_undefines ()
@@ -162,8 +162,8 @@ let _test_balance_of_requests_with_duplicates () =
     ] : FA2_NFT.TZIP12.request list);
     callback = callback_contract;
   } : FA2_NFT.TZIP12.balance_of) in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let _ = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
   let callback_storage = Test.get_storage orig_callback.addr in
   Test.assert (callback_storage = ([1n; 1n; 1n; 0n]))
@@ -185,8 +185,8 @@ let _test_balance_of_0_balance_if_address_does_not_hold_tokens () =
       ] : FA2_NFT.TZIP12.request list);
       callback = callback_contract;
     } : FA2_NFT.TZIP12.balance_of) in
-    let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-    
+    let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
     let _ = Test.transfer orig.addr (Balance_of balance_of_requests) 0tez in
     let callback_storage = Test.get_storage orig_callback.addr in
     Test.assert (callback_storage = ([1n; 1n; 0n]))
@@ -199,8 +199,8 @@ let _test_update_operator_remove_operator_and_transfer () =
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let () = Test.set_source owner1 in
   let _ = Test.transfer orig.addr
     (Update_operators ([
@@ -224,8 +224,8 @@ let _test_update_operator_remove_operator_and_transfer1 () =
   let initial_storage, owners, operators = TestHelpers.get_initial_storage () in
   let owner4 = List_helper.nth_exn 3 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let () = Test.set_source owner4 in
   let _ = Test.transfer orig.addr
     (Update_operators ([
@@ -247,8 +247,8 @@ let _test_update_operator_add_operator_and_transfer () =
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let () = Test.set_source owner1 in
   let _ = Test.transfer orig.addr
     (Update_operators ([
@@ -273,8 +273,8 @@ let _test_update_operator_add_operator_and_transfer1 () =
   let owner2 = List_helper.nth_exn 1 owners in
   let owner4 = List_helper.nth_exn 3 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let () = Test.set_source owner4 in
   let _ = Test.transfer orig.addr
     (Update_operators ([
@@ -298,8 +298,8 @@ let _test_only_sender_manage_operators () =
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
-  
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
+
   let () = Test.set_source owner2 in
   let result = Test.transfer orig.addr
     (Update_operators ([

--- a/test/fa2/nft/views.test.mligo
+++ b/test/fa2/nft/views.test.mligo
@@ -5,14 +5,14 @@
 
 (* Tests for views *)
 
-type orig_nft = (FA2_NFT.NFT parameter_of, FA2_NFT.NFT.storage) origination_result
+type orig_nft = (FA2_NFT parameter_of, FA2_NFT.storage) origination_result
 
 (* Test get_balance view *)
 let test_get_balance_view =
   let initial_storage, owners, _ = TestHelpers.get_initial_storage () in
   let owner1 = List_helper.nth_exn 0 owners in
 
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
 
 
   let initial_storage : ViewsTestContract.storage = {
@@ -24,7 +24,7 @@ let test_get_balance_view =
   } in
 
   let orig_v = Test.originate (contract_of ViewsTestContract) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig_v.addr
     (Get_balance (owner1,1n) : ViewsTestContract parameter_of) 0tez
   in
@@ -36,7 +36,7 @@ let test_get_balance_view =
 let test_total_supply_view =
   let initial_storage, _, _ = TestHelpers.get_initial_storage () in
 
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
 
 
   let initial_storage : ViewsTestContract.storage = {
@@ -48,7 +48,7 @@ let test_total_supply_view =
   } in
 
   let orig_v = Test.originate (contract_of ViewsTestContract) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig_v.addr
     (Total_supply 2n : ViewsTestContract parameter_of) 0tez
   in
@@ -61,7 +61,7 @@ let test_total_supply_view =
 let test_total_supply_undefined_token_view =
   let initial_storage, _, _ = TestHelpers.get_initial_storage () in
 
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
 
 
   let initial_storage : ViewsTestContract.storage = {
@@ -73,7 +73,7 @@ let test_total_supply_undefined_token_view =
   } in
 
   let orig_v = Test.originate (contract_of ViewsTestContract) initial_storage 0tez in
-  
+
   let result = Test.transfer orig_v.addr
     (Total_supply 15n : ViewsTestContract parameter_of) 0tez
   in
@@ -85,7 +85,7 @@ let test_is_operator_view =
   let owner1 = List_helper.nth_exn 0 owners in
   let op1    = List_helper.nth_exn 0 operators in
 
-  let orig = Test.originate (contract_of FA2_NFT.NFT) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_NFT) initial_storage 0tez in
 
 
   let initial_storage : ViewsTestContract.storage = {
@@ -97,7 +97,7 @@ let test_is_operator_view =
   } in
 
   let orig_v = Test.originate (contract_of ViewsTestContract) initial_storage 0tez in
-  
+
   let _ = Test.transfer_exn orig_v.addr
     (Is_operator {
       owner    = owner1;

--- a/test/fa2/single_asset.test.mligo
+++ b/test/fa2/single_asset.test.mligo
@@ -78,18 +78,17 @@ let get_initial_storage (a, b, c : nat * nat * nat) =
 }|}]);
 ]  in
 
-  let initial_storage = {
+  let initial_storage: FA2_single_asset.storage = {
       ledger         = ledger;
       metadata       = metadata;
       token_metadata = token_metadata;
       operators      = operators;
-      extension      = ();
   } in
 
   initial_storage, owners, ops
 
 let assert_balances
-  (contract_address : (FA2_single_asset.SingleAsset parameter_of, FA2_single_asset.SingleAsset.storage) typed_address )
+  (contract_address : (FA2_single_asset parameter_of, FA2_single_asset.storage) typed_address )
   (a, b, c : (address * nat) * (address * nat) * (address * nat)) =
   let (owner1, balance1) = a in
   let (owner2, balance2) = b in
@@ -125,7 +124,7 @@ let test_atomic_tansfer_success =
   ] : FA2_single_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 8n), (owner2, 7n), (owner3, 15n)) in
@@ -144,7 +143,7 @@ let test_atomic_transfer_failure_not_operator =
   ] : FA2_single_asset.TZIP12.transfer)
   in
   let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -165,7 +164,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   ] : FA2_single_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -186,7 +185,7 @@ let test_atomic_tansfer_success_zero_amount_and_self_transfer =
   ] : FA2_single_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 10n), (owner2, 10n), (owner3, 10n)) in
@@ -204,7 +203,7 @@ let test_transfer_failure_transitive_operators =
   ] : FA2_single_asset.TZIP12.transfer)
   in
   let () = Test.set_source op2 in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -224,7 +223,7 @@ let test_empty_transfer_and_balance_of =
     callback = Test.to_contract orig_callback.addr;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -250,7 +249,7 @@ let test_balance_of_requests_with_duplicates =
     callback = Test.to_contract orig_callback.addr;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -276,7 +275,7 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
     callback = Test.to_contract orig_callback.addr;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -292,7 +291,7 @@ let test_update_operator_remove_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let owner3 = List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
 
   let () = Test.set_source owner1 in
@@ -324,7 +323,7 @@ let test_update_operator_add_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let owner3 = List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
 
   let () = Test.set_source owner1 in

--- a/test/fa2/single_asset_jsligo.test.mligo
+++ b/test/fa2/single_asset_jsligo.test.mligo
@@ -77,18 +77,17 @@ let get_initial_storage (a, b, c : nat * nat * nat) =
 }|}]);
 ]  in
 
-  let initial_storage = {
+  let initial_storage: FA2_single_asset.storage = {
       ledger         = ledger;
       metadata       = metadata;
       token_metadata = token_metadata;
       operators      = operators;
-      extension      = ();
   } in
 
   initial_storage, owners, ops
 
 let assert_balances
-  (contract_address : (FA2_single_asset.SingleAsset parameter_of , FA2_single_asset.SingleAsset.storage) typed_address )
+  (contract_address : (FA2_single_asset parameter_of , FA2_single_asset.storage) typed_address )
   (a, b, c : (address * nat) * (address * nat) * (address * nat)) =
   let (owner1, balance1) = a in
   let (owner2, balance2) = b in
@@ -124,7 +123,7 @@ let test_atomic_tansfer_success =
   ] : FA2_single_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 8n), (owner2, 7n), (owner3, 15n)) in
   ()
@@ -142,7 +141,7 @@ let test_atomic_transfer_failure_not_operator =
   ] : FA2_single_asset.TZIP12.transfer)
   in
   let () = Test.set_source op3 in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -163,7 +162,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   ] : FA2_single_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -184,7 +183,7 @@ let test_atomic_tansfer_success_zero_amount_and_self_transfer =
   ] : FA2_single_asset.TZIP12.transfer)
   in
   let () = Test.set_source op1 in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = assert_balances orig.addr ((owner1, 10n), (owner2, 10n), (owner3, 10n)) in
@@ -202,7 +201,7 @@ let test_transfer_failure_transitive_operators =
   ] : FA2_single_asset.TZIP12.transfer)
   in
   let () = Test.set_source op2 in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let result = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   match result with
@@ -223,7 +222,7 @@ let test_empty_transfer_and_balance_of =
     callback = callback_contract;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -249,7 +248,7 @@ let test_balance_of_requests_with_duplicates =
     callback = callback_contract;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -275,7 +274,7 @@ let test_balance_of_0_balance_if_address_does_not_hold_tokens =
     callback = callback_contract;
   } : FA2_single_asset.TZIP12.balance_of) in
 
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
   let _ = Test.transfer_exn orig.addr (Balance_of balance_of_requests) 0tez in
 
@@ -291,7 +290,7 @@ let test_update_operator_remove_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let owner3 = List_helper.nth_exn 2 owners in
   let op1    = List_helper.nth_exn 0 operators in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
 
   let () = Test.set_source owner1 in
@@ -323,7 +322,7 @@ let test_update_operator_add_operator_and_transfer =
   let owner2 = List_helper.nth_exn 1 owners in
   let owner3 = List_helper.nth_exn 2 owners in
   let op3    = List_helper.nth_exn 2 operators in
-  let orig = Test.originate (contract_of FA2_single_asset.SingleAsset) initial_storage 0tez in
+  let orig = Test.originate (contract_of FA2_single_asset) initial_storage 0tez in
 
 
   let () = Test.set_source owner1 in

--- a/test/helpers/nft_helpers.mligo
+++ b/test/helpers/nft_helpers.mligo
@@ -1,4 +1,4 @@
-#import "../../lib/fa2/nft/nft.impl.jsligo" "FA2_NFT"
+#import "../../lib/fa2/nft/nft.impl.mligo" "FA2_NFT"
 
 let get_initial_storage () =
   let () = Test.reset_state 8n ([
@@ -73,19 +73,18 @@ let get_initial_storage () =
 ] in
 
 
-  let initial_storage : FA2_NFT.NFT.storage = {
+  let initial_storage : FA2_NFT.storage = {
     ledger         = ledger;
     token_metadata = token_metadata;
     operators      = operators;
     metadata       = metadata;
-    extension      = ();
   } in
 
   initial_storage, owners, ops
 
 
 let assert_balances
-  (contract_address : (FA2_NFT.NFT parameter_of, FA2_NFT.NFT.storage) typed_address )
+  (contract_address : (FA2_NFT parameter_of, FA2_NFT.storage) typed_address )
   (a, b, c : (address * nat) * (address * nat) * (address * nat)) =
   let (owner1, token_id_1) = a in
   let (owner2, token_id_2) = b in


### PR DESCRIPTION
@Laucans Alternatively, if we don't want the user to concern themself with a `extension = ()` in the storage, we can do as in commit bef232bd44898f9ae3b9d993e98fd10d1928e14c (only implemented for NFT.mligo, look at the `examples/marketplace.jsligo` file). With additional lifting and unlifting operations, we can have a slightly better API, but the code produced is much worse.

See the two attached files, [normal.tz.txt](https://github.com/ligolang/contract-catalogue/files/13703255/normal.tz.txt) and [with-lift.tz.txt](https://github.com/ligolang/contract-catalogue/files/13703256/with-lift.tz.txt). Those are the same contract `NFT.mligo` from both branch (`just-extendable` and the current one). If you `diff` both files, you can see that there's around 75 lines of code that are added. I think the compiler could do much better, but with the current version I'm not sure that's warranted.

By the way, is there a reason for keeping both JSLigo and Mligo implementations? Especially if we expose a single `main.mligo`.