### PR TITLE
Make storage POC 2

### DIFF
--- a/lib/fa2/asset/extendable_multi_asset.impl.jsligo
+++ b/lib/fa2/asset/extendable_multi_asset.impl.jsligo
@@ -22,6 +22,17 @@ export type storage<T> = {
 
 type ret<T> = [list<operation>, storage<T>];
 
+const make_storage = (extension) =>
+   (
+      {
+         ledger: Big_map.empty,
+         operators: Big_map.empty,
+         token_metadata: Big_map.empty,
+         metadata: Big_map.empty,
+         extension: extension
+      }
+   )
+
 //operators
 export const assert_authorisation = (
    [operators, from_, token_id]: [operators, address, nat]

--- a/lib/fa2/asset/extendable_multi_asset.impl.jsligo
+++ b/lib/fa2/asset/extendable_multi_asset.impl.jsligo
@@ -1,230 +1,225 @@
 #import "../common/assertions.jsligo" "Assertions"
+
 #import "../common/errors.mligo" "Errors"
+
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
- export type ledger = big_map<[address, nat], nat>;
- export type operator = address;
- export type operators = big_map<[address, operator], set<nat>>;
- export type storage<T> = {
-    ledger: ledger,
-    operators: operators,
-    token_metadata: TZIP12.tokenMetadata,
-    metadata: TZIP16.metadata,
-    extension: T
- };
- type ret<T> = [list<operation>, storage<T>];
- //operators
+export type ledger = big_map<[address, nat], nat>;
 
- export const assert_authorisation = (
-    [operators, from_, token_id]: [operators, address, nat]
- ): unit => {
-    const sender_ = (Tezos.get_sender());
-    if (sender_ != from_) {
-       const authorized =
-          match((Big_map.find_opt([from_, sender_], operators))) {
-             when (Some(a)):
-                a
-             when (None()):
-                Set.empty
-          };
-       if (! (Set.mem(token_id, authorized))) {
-          return failwith(Errors.not_operator)
-       }
-    }
- };
- export const add_operator = (
-    [operators, owner, operator, token_id]: [
-       operators,
-       address,
-       operator,
-       nat
-    ]
- ): operators => {
-    if (owner == operator) {
-       return operators
-    } // assert_authorisation always allow the owner so this case is not relevant
-     else {
-       Assertions.assert_update_permission(owner);
-       let auth_tokens =
-          match(Big_map.find_opt([owner, operator], operators)) {
-             when (Some(ts)):
-                ts
-             when (None()):
-                Set.empty
-          };
-       auth_tokens = Set.add(token_id, auth_tokens);
-       return Big_map.update([owner, operator], Some(auth_tokens), operators)
-    }
- };
- export const remove_operator = (
-    [operators, owner, operator, token_id]: [
-       operators,
-       address,
-       operator,
-       nat
-    ]
- ): operators => {
-    if (owner == operator) {
-       return operators
-    } // assert_authorisation always allow the owner so this case is not relevant
-     else {
-       Assertions.assert_update_permission(owner);
-       const auth_tokens: option<set<nat>> =
-          match(Big_map.find_opt([owner, operator], operators)) {
-             when (Some(toks)):
-                do {
-                   const ts = Set.remove(token_id, toks);
-                   if (Set.cardinal(ts) == 0n) {
-                      return None()
-                   } else {
-                      return Some(ts)
-                   }
-                }
-             when (None()):
-                None()
-          };
-       return Big_map.update([owner, operator], auth_tokens, operators)
-    }
- }
- // ledger
+export type operator = address;
 
- export const get_for_user = (
-    [ledger, owner, token_id]: [ledger, address, nat]
- ): nat =>
-    match((Big_map.find_opt([owner, token_id], ledger))) {
-       when (Some(a)):
-          a
-       when (None()):
-          0 as nat
-    };
- const set_for_user = (
-    [ledger, owner, token_id, amount_]: [ledger, address, nat, nat]
- ): ledger =>
-    Big_map.update([owner, token_id], Some(amount_), ledger);
- export const decrease_token_amount_for_user = (
-    [ledger, from_, token_id, amount_]: [ledger, address, nat, nat]
- ): ledger => {
-    let balance_ = get_for_user([ledger, from_, token_id]);
-    assert_with_error((balance_ >= amount_), Errors.ins_balance);
-    balance_ = abs(balance_ - amount_);
-    return set_for_user([ledger, from_, token_id, balance_])
- };
- export const increase_token_amount_for_user = (
-    [ledger, to_, token_id, amount_]: [ledger, address, nat, nat]
- ): ledger => {
-    let balance_ = get_for_user([ledger, to_, token_id]);
-    balance_ = balance_ + amount_;
-    return set_for_user([ledger, to_, token_id, balance_])
- }
- // storage
+export type operators = big_map<[address, operator], set<nat>>;
 
- export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
-    ({ ...s, ledger: ledger });
- export const get_operators = <T>(s: storage<T>): operators => s.operators;
- export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
-    ({ ...s, operators: operators })
+export type storage<T> = {
+   ledger: ledger,
+   operators: operators,
+   token_metadata: TZIP12.tokenMetadata,
+   metadata: TZIP16.metadata,
+   extension: T
+};
 
- export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
-    const process_atomic_transfer = (from_: address) =>
-       ([l, t]: [ledger, TZIP12.atomic_trans]): ledger => {
-          const { to_, token_id, amount } = t;
-          Assertions.assert_token_exist(s.token_metadata, token_id);
-          assert_authorisation([s.operators, from_, token_id]);
-          let ledger =
-             decrease_token_amount_for_user([l, from_, token_id, amount]);
-          ledger
-          = increase_token_amount_for_user([ledger, to_, token_id, amount]);
-          return ledger
-       };
-    const process_single_transfer = ([l, t]: [ledger, TZIP12.transfer_from]): ledger => {
-       const { from_, txs } = t;
-       const ledger = List.fold_left(process_atomic_transfer(from_), l, txs);
-       return ledger
-    };
-    const ledger = List.fold_left(process_single_transfer, s.ledger, t);
-    return [list([]), set_ledger([s, ledger])]
- };
+type ret<T> = [list<operation>, storage<T>];
 
- export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
-    const { requests, callback } = b;
-    const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
-       const { owner, token_id } = request;
-       Assertions.assert_token_exist(s.token_metadata, token_id);
-       const balance_ = get_for_user([s.ledger, owner, token_id]);
-       return ({ request: request, balance: balance_ })
-    };
-    const callback_param = List.map(get_balance_info, requests);
-    const operation =
-       Tezos.transaction(Main(callback_param), 0mutez, callback);
-    return [list([operation]), s]
- };
+//operators
+export const assert_authorisation = (
+   [operators, from_, token_id]: [operators, address, nat]
+): unit => {
+   const sender_ = (Tezos.get_sender());
+   if (sender_ != from_) {
+      const authorized =
+         match((Big_map.find_opt([from_, sender_], operators))) {
+            when (Some(a)):
+               a
+            when (None()):
+               Set.empty
+         };
+      if (! (Set.mem(token_id, authorized))) {
+         return failwith(Errors.not_operator)
+      }
+   }
+};
 
- export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
-    const update_operator = (
-       [operators, update]: [operators, TZIP12.unit_update]
-    ): operators =>
-       match(update) {
-          when (Add_operator(operator)):
-             add_operator(
-                [
-                   operators,
-                   operator.owner,
-                   operator.operator,
-                   operator.token_id
-                ]
-             )
-          when (Remove_operator(operator)):
-             remove_operator(
-                [
-                   operators,
-                   operator.owner,
-                   operator.operator,
-                   operator.token_id
-                ]
-             )
-       };
-    let operators = get_operators(s);
-    operators = List.fold_left(update_operator, operators, updates);
-    const store = set_operators([s, operators]);
-    return [list([]), store]
- };
+export const add_operator = (
+   [operators, owner, operator, token_id]: [operators, address, operator, nat]
+): operators => {
+   if (owner == operator) {
+      return operators
+   } // assert_authorisation always allow the owner so this case is not relevant
+    else {
+      Assertions.assert_update_permission(owner);
+      let auth_tokens =
+         match(Big_map.find_opt([owner, operator], operators)) {
+            when (Some(ts)):
+               ts
+            when (None()):
+               Set.empty
+         };
+      auth_tokens = Set.add(token_id, auth_tokens);
+      return Big_map.update([owner, operator], Some(auth_tokens), operators)
+   }
+};
 
- export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
-    const [owner, token_id] = p;
-    Assertions.assert_token_exist(s.token_metadata, token_id);
-    return match(Big_map.find_opt([owner, token_id], s.ledger)) {
-       when (None()):
-          0n
-       when (Some(n)):
-          n
-    }
- };
+export const remove_operator = (
+   [operators, owner, operator, token_id]: [operators, address, operator, nat]
+): operators => {
+   if (owner == operator) {
+      return operators
+   } // assert_authorisation always allow the owner so this case is not relevant
+    else {
+      Assertions.assert_update_permission(owner);
+      const auth_tokens: option<set<nat>> =
+         match(Big_map.find_opt([owner, operator], operators)) {
+            when (Some(toks)):
+               do {
+                  const ts = Set.remove(token_id, toks);
+                  if (Set.cardinal(ts) == 0n) {
+                     return None()
+                  } else {
+                     return Some(ts)
+                  }
+               }
+            when (None()):
+               None()
+         };
+      return Big_map.update([owner, operator], auth_tokens, operators)
+   }
+}
 
- export const total_supply = <T>(_token_id: nat, _s: storage<T>): nat =>
-    failwith(Errors.not_available);
+// ledger
+export const get_for_user = ([ledger, owner, token_id]: [ledger, address, nat]): nat =>
+   match((Big_map.find_opt([owner, token_id], ledger))) {
+      when (Some(a)):
+         a
+      when (None()):
+         0 as nat
+   };
 
- export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
-    failwith(Errors.not_available);
+const set_for_user = (
+   [ledger, owner, token_id, amount_]: [ledger, address, nat, nat]
+): ledger =>
+   Big_map.update([owner, token_id], Some(amount_), ledger);
 
- export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
-    const authorized =
-       match(Big_map.find_opt([op.owner, op.operator], s.operators)) {
-          when (Some(opSet)):
-             opSet
-          when (None()):
-             Set.empty
-       };
-    return (Set.size(authorized) > 0n || op.owner == op.operator)
- };
+export const decrease_token_amount_for_user = (
+   [ledger, from_, token_id, amount_]: [ledger, address, nat, nat]
+): ledger => {
+   let balance_ = get_for_user([ledger, from_, token_id]);
+   assert_with_error((balance_ >= amount_), Errors.ins_balance);
+   balance_ = abs(balance_ - amount_);
+   return set_for_user([ledger, from_, token_id, balance_])
+};
 
- export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
-    return match(Big_map.find_opt(p, s.token_metadata)) {
-       when (Some(data)):
-          data
-       when (None()):
-          failwith(Errors.undefined_token)
-    }
- };
+export const increase_token_amount_for_user = (
+   [ledger, to_, token_id, amount_]: [ledger, address, nat, nat]
+): ledger => {
+   let balance_ = get_for_user([ledger, to_, token_id]);
+   balance_ = balance_ + amount_;
+   return set_for_user([ledger, to_, token_id, balance_])
+}
 
+// storage
+export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
+   ({ ...s, ledger: ledger });
 
+export const get_operators = <T>(s: storage<T>): operators => s.operators;
+
+export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<
+   T
+> =>
+   ({ ...s, operators: operators })
+
+export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
+   const process_atomic_transfer = (from_: address) =>
+      ([l, t]: [ledger, TZIP12.atomic_trans]): ledger => {
+         const { to_, token_id, amount } = t;
+         Assertions.assert_token_exist(s.token_metadata, token_id);
+         assert_authorisation([s.operators, from_, token_id]);
+         let ledger =
+            decrease_token_amount_for_user([l, from_, token_id, amount]);
+         ledger
+         = increase_token_amount_for_user([ledger, to_, token_id, amount]);
+         return ledger
+      };
+   const process_single_transfer = ([l, t]: [ledger, TZIP12.transfer_from]): ledger => {
+      const { from_, txs } = t;
+      const ledger = List.fold_left(process_atomic_transfer(from_), l, txs);
+      return ledger
+   };
+   const ledger = List.fold_left(process_single_transfer, s.ledger, t);
+   return [list([]), set_ledger([s, ledger])]
+};
+
+export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
+   const { requests, callback } = b;
+   const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
+      const { owner, token_id } = request;
+      Assertions.assert_token_exist(s.token_metadata, token_id);
+      const balance_ = get_for_user([s.ledger, owner, token_id]);
+      return ({ request: request, balance: balance_ })
+   };
+   const callback_param = List.map(get_balance_info, requests);
+   const operation = Tezos.transaction(Main(callback_param), 0mutez, callback);
+   return [list([operation]), s]
+};
+
+export const update_operators = <T>(
+   updates: TZIP12.update_operators,
+   s: storage<T>
+): ret<T> => {
+   const update_operator = (
+      [operators, update]: [operators, TZIP12.unit_update]
+   ): operators =>
+      match(update) {
+         when (Add_operator(operator)):
+            add_operator(
+               [operators, operator.owner, operator.operator, operator.token_id]
+            )
+         when (Remove_operator(operator)):
+            remove_operator(
+               [operators, operator.owner, operator.operator, operator.token_id]
+            )
+      };
+   let operators = get_operators(s);
+   operators = List.fold_left(update_operator, operators, updates);
+   const store = set_operators([s, operators]);
+   return [list([]), store]
+};
+
+export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
+   const [owner, token_id] = p;
+   Assertions.assert_token_exist(s.token_metadata, token_id);
+   return match(Big_map.find_opt([owner, token_id], s.ledger)) {
+      when (None()):
+         0n
+      when (Some(n)):
+         n
+   }
+};
+
+export const total_supply = <T>(_token_id: nat, _s: storage<T>): nat =>
+   failwith(Errors.not_available);
+
+export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
+   failwith(Errors.not_available);
+
+export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
+   const authorized =
+      match(Big_map.find_opt([op.owner, op.operator], s.operators)) {
+         when (Some(opSet)):
+            opSet
+         when (None()):
+            Set.empty
+      };
+   return (Set.size(authorized) > 0n || op.owner == op.operator)
+};
+
+export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.
+tokenMetadataData => {
+   return match(Big_map.find_opt(p, s.token_metadata)) {
+      when (Some(data)):
+         data
+      when (None()):
+         failwith(Errors.undefined_token)
+   }
+};

--- a/lib/fa2/asset/extendable_multi_asset.impl.mligo
+++ b/lib/fa2/asset/extendable_multi_asset.impl.mligo
@@ -20,16 +20,16 @@ type 'a storage =
 
 type 'a ret = operation list * 'a storage
 
-let make_storage (type a) (extension : a) : a storage = {
-  ledger = Big_map.empty;
-  operators = Big_map.empty;
-  token_metadata = Big_map.empty;
-  metadata = Big_map.empty;
-  extension = extension;
-}
+let make_storage (type a) (extension : a) : a storage =
+  {
+   ledger = Big_map.empty;
+   operators = Big_map.empty;
+   token_metadata = Big_map.empty;
+   metadata = Big_map.empty;
+   extension = extension
+  }
 
 // Operators
-
 let assert_authorisation
   (operators : operators)
   (from_ : address)
@@ -54,7 +54,6 @@ let add_operator
   if owner = operator
   then operators
   (* assert_authorisation always allow the owner so this case is not relevant *)
-
   else
     let () = Assertions.assert_update_permission owner in
     let auth_tokens =
@@ -73,7 +72,6 @@ let remove_operator
   if owner = operator
   then operators
   (* assert_authorisation always allow the owner so this case is not relevant *)
-
   else
     let () = Assertions.assert_update_permission owner in
     let auth_tokens =
@@ -85,7 +83,6 @@ let remove_operator
     Big_map.update (owner, operator) auth_tokens operators
 
 // Ledger
-
 let get_for_user (ledger : ledger) (owner : address) (token_id : nat) : nat =
   match Big_map.find_opt (owner, token_id) ledger with
     Some (a) -> a
@@ -122,7 +119,6 @@ let increase_token_amount_for_user
   ledger
 
 // Storage
-
 let assert_token_exist (type a) (s : a storage) (token_id : nat) : unit =
   let _ =
     Option.unopt_with_error
@@ -130,7 +126,8 @@ let assert_token_exist (type a) (s : a storage) (token_id : nat) : unit =
       Errors.undefined_token in
   ()
 
-let set_ledger (type a) (s : a storage) (ledger : ledger) = {s with ledger = ledger}
+let set_ledger (type a) (s : a storage) (ledger : ledger) =
+  {s with ledger = ledger}
 
 let get_operators (type a) (s : a storage) = s.operators
 
@@ -139,7 +136,6 @@ let set_operators (type a) (s : a storage) (operators : operators) =
 
 let transfer (type a) (t : TZIP12.transfer) (s : a storage) : a ret =
   (* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se *)
-
   let process_atomic_transfer
     (from_ : address)
     (ledger, t : ledger * TZIP12.atomic_trans) =
@@ -183,7 +179,10 @@ let balance_of (type a) (b : TZIP12.balance_of) (s : a storage) : a ret =
   let operation = Tezos.transaction (Main callback_param) 0mutez callback in
   ([operation] : operation list), s
 
-let update_operators (type a) (updates : TZIP12.update_operators) (s : a storage) : a ret =
+let update_operators (type a)
+  (updates : TZIP12.update_operators)
+  (s : a storage)
+: a ret =
   let update_operator (operators, update : operators * TZIP12.unit_update) =
     match update with
       Add_operator
@@ -227,5 +226,3 @@ let token_metadata (type a) (p : nat) (s : a storage) : TZIP12.tokenMetadataData
   match Big_map.find_opt p s.token_metadata with
     Some (data) -> data
   | None () -> failwith Errors.undefined_token
-
-

--- a/lib/fa2/asset/extendable_multi_asset.impl.mligo
+++ b/lib/fa2/asset/extendable_multi_asset.impl.mligo
@@ -20,6 +20,14 @@ type 'a storage =
 
 type 'a ret = operation list * 'a storage
 
+let make_storage (type a) (extension : a) : a storage = {
+  ledger = Big_map.empty;
+  operators = Big_map.empty;
+  token_metadata = Big_map.empty;
+  metadata = Big_map.empty;
+  extension = extension;
+}
+
 // Operators
 
 let assert_authorisation

--- a/lib/fa2/asset/extendable_single_asset.impl.jsligo
+++ b/lib/fa2/asset/extendable_single_asset.impl.jsligo
@@ -1,152 +1,166 @@
 #import "../common/assertions.jsligo" "Assertions"
+
 #import "../common/errors.mligo" "Errors"
+
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
- export type ledger = big_map<address, nat>;
- export type operator = address;
- export type operators = big_map<address, set<operator>>;
- export type storage<T> = {
-    ledger: ledger,
-    operators: operators,
-    token_metadata: TZIP12.tokenMetadata,
-    metadata: TZIP16.metadata,
-    extension: T
- };
- type ret<T> = [list<operation>, storage<T>];
- // operators
+export type ledger = big_map<address, nat>;
 
- export const assert_authorisation = (operators: operators, from_: address): unit => {
-    const sender_ = Tezos.get_sender();
-    if (sender_ == from_) return unit else {
-       const authorized =
-          match(Big_map.find_opt(from_, operators)) {
-             when (Some(a)):
-                a
-             when (None()):
-                Set.empty
-          };
-       if (Set.mem(sender_, authorized)) return unit else failwith(
-          Errors.not_operator
-       )
-    }
- };
- export const add_operator = (
-    operators: operators,
-    owner: address,
-    operator: operator
- ): operators => {
-    if (owner == operator) return operators else {
-       const _ = Assertions.assert_update_permission(owner);
-       let auths =
-          match(Big_map.find_opt(owner, operators)) {
-             when (Some(os)):
-                os
-             when (None()):
-                Set.empty
-          };
-       auths = Set.add(operator, auths);
-       return Big_map.update(owner, Some(auths), operators)
-    }
- };
- export const remove_operator = (
-    operators: operators,
-    owner: address,
-    operator: operator
- ): operators => {
-    if (owner == operator) return operators else {
-       const _ = Assertions.assert_update_permission(owner);
-       const auths =
-          match(Big_map.find_opt(owner, operators)) {
-             when (None()):
-                None()
-             when (Some(ops)):
-                do {
-                   let os = Set.remove(operator, ops);
-                   if (Set.size(os) == 0n) return None() else return Some(os)
-                }
-          };
-       return Big_map.update(owner, auths, operators)
-    }
- }
- // ledger
+export type operator = address;
 
- export const get_for_user = (ledger: ledger, owner: address): nat =>
-    match(Big_map.find_opt(owner, ledger)) {
-       when (Some(tokens)):
-          tokens
-       when (None()):
-          0 as nat
-    };
- const update_for_user = (ledger: ledger, owner: address, amount_: nat): ledger =>
-    Big_map.update(owner, Some(amount_), ledger);
- export const decrease_token_amount_for_user = (
-    ledger: ledger,
-    from_: address,
-    amount_: nat
- ): ledger => {
-    let tokens = get_for_user(ledger, from_);
-    const _ = assert_with_error(tokens >= amount_, Errors.ins_balance);
-    tokens = abs(tokens - amount_);
-    return update_for_user(ledger, from_, tokens)
- };
- export const increase_token_amount_for_user = (
-    ledger: ledger,
-    to_: address,
-    amount_: nat
- ): ledger => {
-    let tokens = get_for_user(ledger, to_);
-    tokens = tokens + amount_;
-    return update_for_user(ledger, to_, tokens)
- }
- // Storage
+export type operators = big_map<address, set<operator>>;
 
- export const get_amount_for_owner = <T>(s: storage<T>, owner: address) =>
-    get_for_user(s.ledger, owner);
- export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
-    ({ ...s, ledger: ledger });
- export const get_operators = <T>(s: storage<T>): operators => s.operators;
- export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
-    ({ ...s, operators: operators })
+export type storage<T> = {
+   ledger: ledger,
+   operators: operators,
+   token_metadata: TZIP12.tokenMetadata,
+   metadata: TZIP16.metadata,
+   extension: T
+};
 
-  export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
-    /* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se */
+type ret<T> = [list<operation>, storage<T>];
 
-    const process_atomic_transfer = (from_: address) =>
-       ([ledger, t]: [ledger, TZIP12.atomic_trans]): ledger => {
-          const { to_, token_id, amount } = t;
-          ignore(token_id);
-          const _ = assert_authorisation(s.operators, from_);
-          let l = decrease_token_amount_for_user(ledger, from_, amount);
-          return increase_token_amount_for_user(l, to_, amount)
-       };
-    const process_single_transfer = (
-       [ledger, t]: [ledger, TZIP12.transfer_from]
-    ): ledger => {
-       const { from_, txs } = t;
-       return List.fold_left(process_atomic_transfer(from_), ledger, txs)
-    };
-    const ledger = List.fold_left(process_single_transfer, s.ledger, t);
-    const store = set_ledger([s, ledger]);
-    return [list([]), store]
- };
- /** balance_of entrypoint
+// operators
+export const assert_authorisation = (operators: operators, from_: address): unit => {
+   const sender_ = Tezos.get_sender();
+   if (sender_ == from_) return unit else {
+      const authorized =
+         match(Big_map.find_opt(from_, operators)) {
+            when (Some(a)):
+               a
+            when (None()):
+               Set.empty
+         };
+      if (Set.mem(sender_, authorized)) return unit else failwith(
+         Errors.not_operator
+      )
+   }
+};
+
+export const add_operator = (
+   operators: operators,
+   owner: address,
+   operator: operator
+): operators => {
+   if (owner == operator) return operators else {
+      const _ = Assertions.assert_update_permission(owner);
+      let auths =
+         match(Big_map.find_opt(owner, operators)) {
+            when (Some(os)):
+               os
+            when (None()):
+               Set.empty
+         };
+      auths = Set.add(operator, auths);
+      return Big_map.update(owner, Some(auths), operators)
+   }
+};
+
+export const remove_operator = (
+   operators: operators,
+   owner: address,
+   operator: operator
+): operators => {
+   if (owner == operator) return operators else {
+      const _ = Assertions.assert_update_permission(owner);
+      const auths =
+         match(Big_map.find_opt(owner, operators)) {
+            when (None()):
+               None()
+            when (Some(ops)):
+               do {
+                  let os = Set.remove(operator, ops);
+                  if (Set.size(os) == 0n) return None() else return Some(os)
+               }
+         };
+      return Big_map.update(owner, auths, operators)
+   }
+}
+
+// ledger
+export const get_for_user = (ledger: ledger, owner: address): nat =>
+   match(Big_map.find_opt(owner, ledger)) {
+      when (Some(tokens)):
+         tokens
+      when (None()):
+         0 as nat
+   };
+
+const update_for_user = (ledger: ledger, owner: address, amount_: nat): ledger =>
+   Big_map.update(owner, Some(amount_), ledger);
+
+export const decrease_token_amount_for_user = (
+   ledger: ledger,
+   from_: address,
+   amount_: nat
+): ledger => {
+   let tokens = get_for_user(ledger, from_);
+   const _ = assert_with_error(tokens >= amount_, Errors.ins_balance);
+   tokens = abs(tokens - amount_);
+   return update_for_user(ledger, from_, tokens)
+};
+
+export const increase_token_amount_for_user = (
+   ledger: ledger,
+   to_: address,
+   amount_: nat
+): ledger => {
+   let tokens = get_for_user(ledger, to_);
+   tokens = tokens + amount_;
+   return update_for_user(ledger, to_, tokens)
+}
+
+// Storage
+export const get_amount_for_owner = <T>(s: storage<T>, owner: address) =>
+   get_for_user(s.ledger, owner);
+
+export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
+   ({ ...s, ledger: ledger });
+
+export const get_operators = <T>(s: storage<T>): operators => s.operators;
+
+export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<
+   T
+> =>
+   ({ ...s, operators: operators })
+
+export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
+   /* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se */
+   const process_atomic_transfer = (from_: address) =>
+      ([ledger, t]: [ledger, TZIP12.atomic_trans]): ledger => {
+         const { to_, token_id, amount } = t;
+         ignore(token_id);
+         const _ = assert_authorisation(s.operators, from_);
+         let l = decrease_token_amount_for_user(ledger, from_, amount);
+         return increase_token_amount_for_user(l, to_, amount)
+      };
+   const process_single_transfer = ([ledger, t]: [ledger, TZIP12.transfer_from]): ledger => {
+      const { from_, txs } = t;
+      return List.fold_left(process_atomic_transfer(from_), ledger, txs)
+   };
+   const ledger = List.fold_left(process_single_transfer, s.ledger, t);
+   const store = set_ledger([s, ledger]);
+   return [list([]), store]
+};
+
+/** balance_of entrypoint
 */
+export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
+   const { requests, callback } = b;
+   const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
+      const { owner, token_id } = request;
+      ignore(token_id);
+      const balance_ = get_amount_for_owner(s, owner);
+      return { request: request, balance: balance_ }
+   };
+   const callback_param = List.map(get_balance_info, requests);
+   const operation = Tezos.transaction(Main(callback_param), 0mutez, callback);
+   return [list([operation]), s]
+};
 
- export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
-    const { requests, callback } = b;
-    const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
-       const { owner, token_id } = request;
-       ignore(token_id);
-       const balance_ = get_amount_for_owner(s, owner);
-       return { request: request, balance: balance_ }
-    };
-    const callback_param = List.map(get_balance_info, requests);
-    const operation =
-       Tezos.transaction(Main(callback_param), 0mutez, callback);
-    return [list([operation]), s]
- };
- /**
+/**
 Add or Remove token operators for the specified token owners and token IDs.
 
 
@@ -164,58 +178,58 @@ operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
 
 
 */
+export const update_operators = <T>(
+   updates: TZIP12.update_operators,
+   s: storage<T>
+): ret<T> => {
+   const update_operator = (
+      [operators, update]: [operators, TZIP12.unit_update]
+   ): operators =>
+      match(update) {
+         when (Add_operator(operator)):
+            add_operator(operators, operator.owner, operator.operator)
+         when (Remove_operator(operator)):
+            remove_operator(operators, operator.owner, operator.operator)
+      };
+   const operators = List.fold_left(update_operator, get_operators(s), updates);
+   const store = set_operators([s, operators]);
+   return [list([]), store]
+};
 
- export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
-    const update_operator = (
-       [operators, update]: [operators, TZIP12.unit_update]
-    ): operators =>
-       match(update) {
-          when (Add_operator(operator)):
-             add_operator(operators, operator.owner, operator.operator)
-          when (Remove_operator(operator)):
-             remove_operator(operators, operator.owner, operator.operator)
-       };
-    const operators =
-       List.fold_left(update_operator, get_operators(s), updates);
-    const store = set_operators([s, operators]);
-    return [list([]), store]
- };
+export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
+   const [owner, token_id] = p;
+   Assertions.assert_token_exist(s.token_metadata, token_id);
+   return match(Big_map.find_opt(owner, s.ledger)) {
+      when (None()):
+         0n
+      when (Some(n)):
+         n
+   }
+};
 
- export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
-    const [owner, token_id] = p;
-    Assertions.assert_token_exist(s.token_metadata, token_id);
-    return match(Big_map.find_opt(owner, s.ledger)) {
-       when (None()):
-          0n
-       when (Some(n)):
-          n
-    }
- };
+export const total_supply = <T>(_token_id: nat, _s: storage<T>): nat =>
+   failwith(Errors.not_available);
 
- export const total_supply = <T>(_token_id: nat, _s: storage<T>): nat =>
-    failwith(Errors.not_available);
+export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
+   failwith(Errors.not_available);
 
- export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
-    failwith(Errors.not_available);
+export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
+   const authorized =
+      match(Big_map.find_opt(op.owner, s.operators)) {
+         when (Some(opSet)):
+            opSet
+         when (None()):
+            Set.empty
+      };
+   return (Set.mem(op.operator, authorized) || op.owner == op.operator)
+};
 
- export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
-    const authorized =
-       match(Big_map.find_opt(op.owner, s.operators)) {
-          when (Some(opSet)):
-             opSet
-          when (None()):
-             Set.empty
-       };
-    return (Set.mem(op.operator, authorized) || op.owner == op.operator)
- };
-
- export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
-    return match(Big_map.find_opt(p, s.token_metadata)) {
-       when (Some(data)):
-          data
-       when (None()):
-          failwith(Errors.undefined_token)
-    }
- };
-
-
+export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.
+tokenMetadataData => {
+   return match(Big_map.find_opt(p, s.token_metadata)) {
+      when (Some(data)):
+         data
+      when (None()):
+         failwith(Errors.undefined_token)
+   }
+};

--- a/lib/fa2/asset/extendable_single_asset.impl.jsligo
+++ b/lib/fa2/asset/extendable_single_asset.impl.jsligo
@@ -22,6 +22,17 @@ export type storage<T> = {
 
 type ret<T> = [list<operation>, storage<T>];
 
+const make_storage = (extension) =>
+   (
+      {
+         ledger: Big_map.empty,
+         operators: Big_map.empty,
+         token_metadata: Big_map.empty,
+         metadata: Big_map.empty,
+         extension: extension
+      }
+   )
+
 // operators
 export const assert_authorisation = (operators: operators, from_: address): unit => {
    const sender_ = Tezos.get_sender();

--- a/lib/fa2/asset/extendable_single_asset.impl.mligo
+++ b/lib/fa2/asset/extendable_single_asset.impl.mligo
@@ -20,6 +20,15 @@ type 'a storage =
 
 type 'a ret = operation list * 'a storage
 
+let make_storage (type a) (extension : a) : a storage =
+  {
+   ledger = Big_map.empty;
+   operators = Big_map.empty;
+   token_metadata = Big_map.empty;
+   metadata = Big_map.empty;
+   extension = extension
+  }
+
 // Operators
 let assert_authorisation (operators : operators) (from_ : address) : unit =
   let sender_ = (Tezos.get_sender ()) in

--- a/lib/fa2/asset/extendable_single_asset.impl.mligo
+++ b/lib/fa2/asset/extendable_single_asset.impl.mligo
@@ -3,25 +3,24 @@
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
-
 type ledger = (address, nat) big_map
 
 type operator = address
 
 type operators = (address, operator set) big_map
 
-type 'a storage = {
+type 'a storage =
+  {
    ledger : ledger;
    operators : operators;
    token_metadata : TZIP12.tokenMetadata;
    metadata : TZIP16.metadata;
-   extension: 'a
+   extension : 'a
   }
 
 type 'a ret = operation list * 'a storage
 
 // Operators
-
 let assert_authorisation (operators : operators) (from_ : address) : unit =
   let sender_ = (Tezos.get_sender ()) in
   if (sender_ = from_)
@@ -33,15 +32,11 @@ let assert_authorisation (operators : operators) (from_ : address) : unit =
       | None -> Set.empty in
     if Set.mem sender_ authorized then () else failwith Errors.not_operator
 
-let add_operator
-  (operators : operators)
-  (owner : address)
-  (operator : operator)
+let add_operator (operators : operators) (owner : address) (operator : operator)
 : operators =
   if owner = operator
   then operators
   (* assert_authorisation always allow the owner so this case is not relevant *)
-
   else
     let () = Assertions.assert_update_permission owner in
     let auths =
@@ -59,7 +54,6 @@ let remove_operator
   if owner = operator
   then operators
   (* assert_authorisation always allow the owner so this case is not relevant *)
-
   else
     let () = Assertions.assert_update_permission owner in
     let auths =
@@ -71,14 +65,13 @@ let remove_operator
     Big_map.update owner auths operators
 
 // Ledger
-
 let get_for_user (ledger : ledger) (owner : address) : nat =
   match Big_map.find_opt owner ledger with
     Some (tokens) -> tokens
   | None -> 0n
 
-let update_for_user (ledger : ledger) (owner : address) (amount_ : nat)
-: ledger = Big_map.update owner (Some amount_) ledger
+let update_for_user (ledger : ledger) (owner : address) (amount_ : nat) : ledger =
+  Big_map.update owner (Some amount_) ledger
 
 let decrease_token_amount_for_user
   (ledger : ledger)
@@ -102,11 +95,11 @@ let increase_token_amount_for_user
   ledger
 
 // Storage
-
 let get_amount_for_owner (type a) (s : a storage) (owner : address) =
   get_for_user s.ledger owner
 
-let set_ledger (type a) (s : a storage) (ledger : ledger) = {s with ledger = ledger}
+let set_ledger (type a) (s : a storage) (ledger : ledger) =
+  {s with ledger = ledger}
 
 let get_operators (type a) (s : a storage) = s.operators
 
@@ -114,49 +107,48 @@ let set_operators (type a) (s : a storage) (operators : operators) =
   {s with operators = operators}
 
 let transfer (type a) (t : TZIP12.transfer) (s : a storage) : a ret =
-    (* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se *)
-
-    let process_atomic_transfer
-      (from_ : address)
-      (ledger, t : ledger * TZIP12.atomic_trans) =
-      let {
-       to_;
-       token_id = _token_id;
-       amount = amount_
-      } = t in
-      let () = assert_authorisation s.operators from_ in
-      let ledger = decrease_token_amount_for_user ledger from_ amount_ in
-      let ledger = increase_token_amount_for_user ledger to_ amount_ in
-      ledger in
-    let process_single_transfer (ledger, t : ledger * TZIP12.transfer_from) =
-      let {
-       from_;
-       txs
-      } = t in
-      let ledger = List.fold_left (process_atomic_transfer from_) ledger txs in
-      ledger in
-    let ledger = List.fold_left process_single_transfer s.ledger t in
-    let s = set_ledger s ledger in
-    ([] : operation list), s
+  (* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se *)
+  let process_atomic_transfer
+    (from_ : address)
+    (ledger, t : ledger * TZIP12.atomic_trans) =
+    let {
+     to_;
+     token_id = _token_id;
+     amount = amount_
+    } = t in
+    let () = assert_authorisation s.operators from_ in
+    let ledger = decrease_token_amount_for_user ledger from_ amount_ in
+    let ledger = increase_token_amount_for_user ledger to_ amount_ in
+    ledger in
+  let process_single_transfer (ledger, t : ledger * TZIP12.transfer_from) =
+    let {
+     from_;
+     txs
+    } = t in
+    let ledger = List.fold_left (process_atomic_transfer from_) ledger txs in
+    ledger in
+  let ledger = List.fold_left process_single_transfer s.ledger t in
+  let s = set_ledger s ledger in
+  ([] : operation list), s
 
 let balance_of (type a) (b : TZIP12.balance_of) (s : a storage) : a ret =
   let {
-     requests;
-     callback
-    } = b in
-    let get_balance_info (request : TZIP12.request) : TZIP12.callback =
-      let {
-       owner;
-       token_id = _token_id
-      } = request in
-      let balance_ = get_amount_for_owner s owner in
-      {
-       request = request;
-       balance = balance_
-      } in
-    let callback_param = List.map get_balance_info requests in
-    let operation = Tezos.transaction (Main callback_param) 0mutez callback in
-    ([operation] : operation list), s
+   requests;
+   callback
+  } = b in
+  let get_balance_info (request : TZIP12.request) : TZIP12.callback =
+    let {
+     owner;
+     token_id = _token_id
+    } = request in
+    let balance_ = get_amount_for_owner s owner in
+    {
+     request = request;
+     balance = balance_
+    } in
+  let callback_param = List.map get_balance_info requests in
+  let operation = Tezos.transaction (Main callback_param) 0mutez callback in
+  ([operation] : operation list), s
 
 (**
 Add or Remove token operators for the specified token owners and token IDs.
@@ -176,27 +168,28 @@ operator of A, C cannot transfer tokens that are owned by A, on behalf of B.
 
 
 *)
-
-let update_operators (type a) (updates : TZIP12.update_operators) (s : a storage) : a ret =
-  let update_operator
-      (operators, update : operators * TZIP12.unit_update) =
-      match update with
-        Add_operator
-          {
-           owner = owner;
-           operator = operator;
-           token_id = _token_id
-          } -> add_operator operators owner operator
-      | Remove_operator
-          {
-           owner = owner;
-           operator = operator;
-           token_id = _token_id
-          } -> remove_operator operators owner operator in
-    let operators = get_operators s in
-    let operators = List.fold_left update_operator operators updates in
-    let s = set_operators s operators in
-    ([] : operation list), s
+let update_operators (type a)
+  (updates : TZIP12.update_operators)
+  (s : a storage)
+: a ret =
+  let update_operator (operators, update : operators * TZIP12.unit_update) =
+    match update with
+      Add_operator
+        {
+         owner = owner;
+         operator = operator;
+         token_id = _token_id
+        } -> add_operator operators owner operator
+    | Remove_operator
+        {
+         owner = owner;
+         operator = operator;
+         token_id = _token_id
+        } -> remove_operator operators owner operator in
+  let operators = get_operators s in
+  let operators = List.fold_left update_operator operators updates in
+  let s = set_operators s operators in
+  ([] : operation list), s
 
 let get_balance (type a) (p : (address * nat)) (s : a storage) : nat =
   let (owner, token_id) = p in
@@ -222,5 +215,3 @@ let token_metadata (type a) (p : nat) (s : a storage) : TZIP12.tokenMetadataData
   match Big_map.find_opt p s.token_metadata with
     Some (data) -> data
   | None () -> failwith Errors.undefined_token
-
-

--- a/lib/fa2/asset/multi_asset.impl.jsligo
+++ b/lib/fa2/asset/multi_asset.impl.jsligo
@@ -1,20 +1,34 @@
 #import "../common/assertions.jsligo" "Assertions"
+
 #import "../common/errors.mligo" "Errors"
+
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
+
 #import "./extendable_multi_asset.impl.jsligo" "MultiAssetExtendable"
 
 export type ledger = MultiAssetExtendable.ledger;
+
 export type operator = MultiAssetExtendable.operator;
+
 export type operators = MultiAssetExtendable.operators;
+
 export type storage = {
-   ledger : ledger,
-   operators : operators,
-   token_metadata : TZIP12.tokenMetadata,
-   metadata : TZIP16.metadata,
+  ledger: ledger,
+  operators: operators,
+  token_metadata: TZIP12.tokenMetadata,
+  metadata: TZIP16.metadata,
 }
 
 type ret = [list<operation>, storage];
+
+const empty_storage: storage = {
+  ledger: Big_map.empty,
+  operators: Big_map.empty,
+  token_metadata: Big_map.empty,
+  metadata: Big_map.empty
+}
 
 @inline
 const lift = (s: storage): MultiAssetExtendable.storage<unit> => {

--- a/lib/fa2/asset/multi_asset.impl.mligo
+++ b/lib/fa2/asset/multi_asset.impl.mligo
@@ -11,30 +11,32 @@ type operator = MultiAssetExtendable.operator
 
 type operators = MultiAssetExtendable.operators
 
-type storage = {
-  ledger : ledger;
-  operators : operators;
-  token_metadata : TZIP12.tokenMetadata;
-  metadata : TZIP16.metadata;
-}
+type storage =
+  {
+   ledger : ledger;
+   operators : operators;
+   token_metadata : TZIP12.tokenMetadata;
+   metadata : TZIP16.metadata
+  }
 
 type ret = operation list * storage
 
-let empty_storage : storage = {
-  ledger = Big_map.empty;
-  operators = Big_map.empty;
-  token_metadata = Big_map.empty;
-  metadata = Big_map.empty
-}
+let empty_storage : storage =
+  {
+   ledger = Big_map.empty;
+   operators = Big_map.empty;
+   token_metadata = Big_map.empty;
+   metadata = Big_map.empty
+  }
 
 [@inline]
 let lift (s : storage) : unit MultiAssetExtendable.storage =
   {
-    extension = ();
-    ledger = s.ledger;
-    operators = s.operators;
-    token_metadata = s.token_metadata;
-    metadata = s.metadata;
+   extension = ();
+   ledger = s.ledger;
+   operators = s.operators;
+   token_metadata = s.token_metadata;
+   metadata = s.metadata
   }
 
 [@inline]
@@ -42,10 +44,10 @@ let unlift (ret : operation list * unit MultiAssetExtendable.storage) : ret =
   let ops, s = ret in
   ops,
   {
-    ledger = s.ledger;
-    operators = s.operators;
-    token_metadata = s.token_metadata;
-    metadata = s.metadata;
+   ledger = s.ledger;
+   operators = s.operators;
+   token_metadata = s.token_metadata;
+   metadata = s.metadata
   }
 
 [@entry]

--- a/lib/fa2/asset/multi_asset.impl.mligo
+++ b/lib/fa2/asset/multi_asset.impl.mligo
@@ -12,13 +12,20 @@ type operator = MultiAssetExtendable.operator
 type operators = MultiAssetExtendable.operators
 
 type storage = {
-   ledger : ledger;
-   operators : operators;
-   token_metadata : TZIP12.tokenMetadata;
-   metadata : TZIP16.metadata;
+  ledger : ledger;
+  operators : operators;
+  token_metadata : TZIP12.tokenMetadata;
+  metadata : TZIP16.metadata;
 }
 
 type ret = operation list * storage
+
+let empty_storage : storage = {
+  ledger = Big_map.empty;
+  operators = Big_map.empty;
+  token_metadata = Big_map.empty;
+  metadata = Big_map.empty
+}
 
 [@inline]
 let lift (s : storage) : unit MultiAssetExtendable.storage =

--- a/lib/fa2/asset/single_asset.impl.jsligo
+++ b/lib/fa2/asset/single_asset.impl.jsligo
@@ -1,22 +1,38 @@
 #import "../common/assertions.jsligo" "Assertions"
+
 #import "../common/errors.mligo" "Errors"
+
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+
 #import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
+
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
+
 #import "./extendable_single_asset.impl.jsligo" "SingleAssetExtendable"
 
 export type ledger = SingleAssetExtendable.ledger;
+
 export type operator = SingleAssetExtendable.operator;
+
 export type operators = SingleAssetExtendable.operators;
+
 export type storage = SingleAssetExtendable.storage<unit>;
+
 export type storage = {
-   ledger : ledger,
-   operators : operators,
-   token_metadata : TZIP12.tokenMetadata,
-   metadata : TZIP16.metadata,
+  ledger: ledger,
+  operators: operators,
+  token_metadata: TZIP12.tokenMetadata,
+  metadata: TZIP16.metadata,
 }
 
 type ret = [list<operation>, storage];
+
+const empty_storage: storage = {
+  ledger: Big_map.empty,
+  operators: Big_map.empty,
+  token_metadata: Big_map.empty,
+  metadata: Big_map.empty
+}
 
 @inline
 const lift = (s: storage): SingleAssetExtendable.storage<unit> => {
@@ -30,7 +46,9 @@ const lift = (s: storage): SingleAssetExtendable.storage<unit> => {
 }
 
 @inline
-const unlift = ([ops, s]: [list<operation>, SingleAssetExtendable.storage<unit>]): ret => {
+const unlift = (
+  [ops, s]: [list<operation>, SingleAssetExtendable.storage<unit>]
+): ret => {
   let storage = {
     ledger: s.ledger,
     operators: s.operators,

--- a/lib/fa2/asset/single_asset.impl.mligo
+++ b/lib/fa2/asset/single_asset.impl.mligo
@@ -13,30 +13,32 @@ type operators = SingleAssetExtendable.operators
 
 type storage = unit SingleAssetExtendable.storage
 
-type storage = {
+type storage =
+  {
    ledger : ledger;
    operators : operators;
    token_metadata : TZIP12.tokenMetadata;
-   metadata : TZIP16.metadata;
-}
+   metadata : TZIP16.metadata
+  }
 
 type ret = operation list * storage
 
-let empty_storage : storage = {
-  ledger = Big_map.empty;
-  operators = Big_map.empty;
-  token_metadata = Big_map.empty;
-  metadata = Big_map.empty
-}
+let empty_storage : storage =
+  {
+   ledger = Big_map.empty;
+   operators = Big_map.empty;
+   token_metadata = Big_map.empty;
+   metadata = Big_map.empty
+  }
 
 [@inline]
 let lift (s : storage) : unit SingleAssetExtendable.storage =
   {
-    extension = ();
-    ledger = s.ledger;
-    operators = s.operators;
-    token_metadata = s.token_metadata;
-    metadata = s.metadata;
+   extension = ();
+   ledger = s.ledger;
+   operators = s.operators;
+   token_metadata = s.token_metadata;
+   metadata = s.metadata
   }
 
 [@inline]
@@ -44,10 +46,10 @@ let unlift (ret : operation list * unit SingleAssetExtendable.storage) : ret =
   let ops, s = ret in
   ops,
   {
-    ledger = s.ledger;
-    operators = s.operators;
-    token_metadata = s.token_metadata;
-    metadata = s.metadata;
+   ledger = s.ledger;
+   operators = s.operators;
+   token_metadata = s.token_metadata;
+   metadata = s.metadata
   }
 
 [@entry]

--- a/lib/fa2/asset/single_asset.impl.mligo
+++ b/lib/fa2/asset/single_asset.impl.mligo
@@ -22,6 +22,13 @@ type storage = {
 
 type ret = operation list * storage
 
+let empty_storage : storage = {
+  ledger = Big_map.empty;
+  operators = Big_map.empty;
+  token_metadata = Big_map.empty;
+  metadata = Big_map.empty
+}
+
 [@inline]
 let lift (s : storage) : unit SingleAssetExtendable.storage =
   {

--- a/lib/fa2/nft/extendable_nft.impl.jsligo
+++ b/lib/fa2/nft/extendable_nft.impl.jsligo
@@ -23,6 +23,17 @@ export type storage<T> = {
 
 type ret<T> = [list<operation>, storage<T>];
 
+const make_storage = (extension) =>
+   (
+      {
+         ledger: Big_map.empty,
+         operators: Big_map.empty,
+         token_metadata: Big_map.empty,
+         metadata: Big_map.empty,
+         extension: extension
+      }
+   )
+
 //** LIGOFA_NFT
 export const assert_authorisation = (
    operators: operators,

--- a/lib/fa2/nft/extendable_nft.impl.jsligo
+++ b/lib/fa2/nft/extendable_nft.impl.jsligo
@@ -1,125 +1,131 @@
 #import "../common/assertions.jsligo" "Assertions"
+
 #import "../common/errors.mligo" "Errors"
+
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 export type ledger = big_map<nat, address>;
+
 export type operator = address;
+
 export type operators = big_map<[address, operator], set<nat>>; //[owner,operator]
 
+
 export type storage<T> = {
-  ledger: ledger,
-  operators: operators,
-  token_metadata: TZIP12.tokenMetadata,
-  metadata: TZIP16.metadata,
-  extension: T
+   ledger: ledger,
+   operators: operators,
+   token_metadata: TZIP12.tokenMetadata,
+   metadata: TZIP16.metadata,
+   extension: T
 };
+
 type ret<T> = [list<operation>, storage<T>];
+
 //** LIGOFA_NFT
-
 export const assert_authorisation = (
-  operators: operators,
-  from_: address,
-  token_id: nat
+   operators: operators,
+   from_: address,
+   token_id: nat
 ): unit => {
-  const sender_ = (Tezos.get_sender());
-  if (sender_ != from_) {
-     const authorized =
-        match((Big_map.find_opt([from_, sender_], operators))) {
-           when (Some(a)):
-              a
-           when (None()):
-              Set.empty
-        };
-     if (! (Set.mem(token_id, authorized))) {
-        return failwith(Errors.not_operator)
-     }
-  } else {
-     return unit
-  }
+   const sender_ = (Tezos.get_sender());
+   if (sender_ != from_) {
+      const authorized =
+         match((Big_map.find_opt([from_, sender_], operators))) {
+            when (Some(a)):
+               a
+            when (None()):
+               Set.empty
+         };
+      if (! (Set.mem(token_id, authorized))) {
+         return failwith(Errors.not_operator)
+      }
+   } else {
+      return unit
+   }
 };
+
 export const add_operator = (
-  operators: operators,
-  owner: address,
-  operator: address,
-  token_id: nat
+   operators: operators,
+   owner: address,
+   operator: address,
+   token_id: nat
 ): operators => {
-  if (owner == operator) {
-     return operators
-  // assert_authorisation always allow the owner so this case is not relevant
-
-  } else {
-     Assertions.assert_update_permission(owner);
-     let auth_tokens =
-        match(Big_map.find_opt([owner, operator], operators)) {
-           when (Some(ts)):
-              ts
-           when (None()):
-              Set.empty
-        };
-     auth_tokens = Set.add(token_id, auth_tokens);
-     return Big_map.update([owner, operator], Some(auth_tokens), operators)
-  }
+   if (owner == operator) {
+      return operators
+   // assert_authorisation always allow the owner so this case is not relevant
+   } else {
+      Assertions.assert_update_permission(owner);
+      let auth_tokens =
+         match(Big_map.find_opt([owner, operator], operators)) {
+            when (Some(ts)):
+               ts
+            when (None()):
+               Set.empty
+         };
+      auth_tokens = Set.add(token_id, auth_tokens);
+      return Big_map.update([owner, operator], Some(auth_tokens), operators)
+   }
 };
+
 export const remove_operator = (
-  operators: operators,
-  owner: address,
-  operator: address,
-  token_id: nat
+   operators: operators,
+   owner: address,
+   operator: address,
+   token_id: nat
 ): operators => {
-  if (owner == operator) {
-     return operators
-  // assert_authorisation always allow the owner so this case is not relevant
-
-  } else {
-     Assertions.assert_update_permission(owner);
-     const auth_tokens: option<set<nat>> =
-        match(Big_map.find_opt([owner, operator], operators)) {
-           when (Some(ts)):
-              do {
-                 const toks = Set.remove(token_id, ts);
-                 if (Set.cardinal(toks) == 0n) {
-                    return None()
-                 } else {
-                    return Some(toks)
-                 }
-              }
-           when (None()):
-              None()
-        };
-     return Big_map.update([owner, operator], auth_tokens, operators)
-  }
+   if (owner == operator) {
+      return operators
+   // assert_authorisation always allow the owner so this case is not relevant
+   } else {
+      Assertions.assert_update_permission(owner);
+      const auth_tokens: option<set<nat>> =
+         match(Big_map.find_opt([owner, operator], operators)) {
+            when (Some(ts)):
+               do {
+                  const toks = Set.remove(token_id, ts);
+                  if (Set.cardinal(toks) == 0n) {
+                     return None()
+                  } else {
+                     return Some(toks)
+                  }
+               }
+            when (None()):
+               None()
+         };
+      return Big_map.update([owner, operator], auth_tokens, operators)
+   }
 }
-//  ledger
 
+//  ledger
 export const is_owner_of = (ledger: ledger, token_id: nat, owner: address): bool => {
-  const current_owner = Option.unopt(Big_map.find_opt(token_id, ledger));
-  return (current_owner == owner)
+   const current_owner = Option.unopt(Big_map.find_opt(token_id, ledger));
+   return (current_owner == owner)
 };
-export const assert_owner_of = (
-  ledger: ledger,
-  token_id: nat,
-  owner: address
-): unit =>
-  assert_with_error(
-     is_owner_of(ledger, token_id, owner),
-     Errors.ins_balance
-  );
+
+export const assert_owner_of = (ledger: ledger, token_id: nat, owner: address): unit =>
+   assert_with_error(is_owner_of(ledger, token_id, owner), Errors.ins_balance);
+
 export const transfer_token_from_user_to_user = (
-  ledger: ledger,
-  token_id: nat,
-  from_: address,
-  to_: address
+   ledger: ledger,
+   token_id: nat,
+   from_: address,
+   to_: address
 ): ledger => {
-  assert_owner_of(ledger, token_id, from_);
-  return Big_map.update(token_id, Some(to_), ledger)
+   assert_owner_of(ledger, token_id, from_);
+   return Big_map.update(token_id, Some(to_), ledger)
 }
 
 export const set_ledger = <T>([s, ledger]: [storage<T>, ledger]): storage<T> =>
-  ({ ...s, ledger: ledger });
+   ({ ...s, ledger: ledger });
+
 export const get_operators = <T>(s: storage<T>): operators => s.operators;
-export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<T> =>
-  ({ ...s, operators: operators })
+
+export const set_operators = <T>([s, operators]: [storage<T>, operators]): storage<
+   T
+> =>
+   ({ ...s, operators: operators })
 
 //** TZIP12Interface.FA2
 //  operators
@@ -129,107 +135,102 @@ export const set_operators = <T>([s, operators]: [storage<T>, operators]): stora
 * @param from_ : transfer from address
 * @param token_id : token_id to test
 */
-
 export const transfer = <T>(t: TZIP12.transfer, s: storage<T>): ret<T> => {
-  const process_atomic_transfer = (from_: address) =>
-     ([ledger, t]: [ledger, TZIP12.atomic_trans]): ledger => {
-        const { to_, token_id, amount } = t;
-        ignore(amount);
-        Assertions.assert_token_exist(s.token_metadata, token_id);
-        assert_authorisation(s.operators, from_, token_id);
-        return transfer_token_from_user_to_user(
-           ledger,
-           token_id,
-           from_,
-           to_
-        )
-     };
-  const process_single_transfer = (
-     [ledger, t]: [ledger, TZIP12.transfer_from]
-  ): ledger => {
-     const { from_, txs } = t;
-     return List.fold_left(process_atomic_transfer(from_), ledger, txs)
-  };
-  const ledger = List.fold_left(process_single_transfer, s.ledger, t);
-  const store = set_ledger([s, ledger]);
-  return [list([]), store]
+   const process_atomic_transfer = (from_: address) =>
+      ([ledger, t]: [ledger, TZIP12.atomic_trans]): ledger => {
+         const { to_, token_id, amount } = t;
+         ignore(amount);
+         Assertions.assert_token_exist(s.token_metadata, token_id);
+         assert_authorisation(s.operators, from_, token_id);
+         return transfer_token_from_user_to_user(ledger, token_id, from_, to_)
+      };
+   const process_single_transfer = ([ledger, t]: [ledger, TZIP12.transfer_from]): ledger => {
+      const { from_, txs } = t;
+      return List.fold_left(process_atomic_transfer(from_), ledger, txs)
+   };
+   const ledger = List.fold_left(process_single_transfer, s.ledger, t);
+   const store = set_ledger([s, ledger]);
+   return [list([]), store]
 };
 
 export const balance_of = <T>(b: TZIP12.balance_of, s: storage<T>): ret<T> => {
-  const { requests, callback } = b;
-  const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
-     const { owner, token_id } = request;
-     Assertions.assert_token_exist(s.token_metadata, token_id);
-     let balance_ = 0 as nat;
-     if (is_owner_of(s.ledger, token_id, owner)) balance_ = 1 as nat;
-     return ({ request: request, balance: balance_ })
-  };
-  const callback_param = List.map(get_balance_info, requests);
-  const operation =
-     Tezos.transaction(Main(callback_param), 0mutez, callback);
-  return [list([operation]), s]
+   const { requests, callback } = b;
+   const get_balance_info = (request: TZIP12.request): TZIP12.callback => {
+      const { owner, token_id } = request;
+      Assertions.assert_token_exist(s.token_metadata, token_id);
+      let balance_ = 0 as nat;
+      if (is_owner_of(s.ledger, token_id, owner)) balance_ = 1 as nat;
+      return ({ request: request, balance: balance_ })
+   };
+   const callback_param = List.map(get_balance_info, requests);
+   const operation = Tezos.transaction(Main(callback_param), 0mutez, callback);
+   return [list([operation]), s]
 };
 
-export const update_operators = <T>(updates: TZIP12.update_operators, s: storage<T>): ret<T> => {
-  const update_operator = (
-     [operators, update]: [operators, TZIP12.unit_update]
-  ): operators =>
-     match(update) {
-        when (Add_operator(operator)):
-           add_operator(
-              operators,
-              operator.owner,
-              operator.operator,
-              operator.token_id
-           )
-        when (Remove_operator(operator)):
-           remove_operator(
-              operators,
-              operator.owner,
-              operator.operator,
-              operator.token_id
-           )
-     };
-  let operators = get_operators(s);
-  operators = List.fold_left(update_operator, operators, updates);
-  const store = set_operators([s, operators]);
-  return [list([]), store]
+export const update_operators = <T>(
+   updates: TZIP12.update_operators,
+   s: storage<T>
+): ret<T> => {
+   const update_operator = (
+      [operators, update]: [operators, TZIP12.unit_update]
+   ): operators =>
+      match(update) {
+         when (Add_operator(operator)):
+            add_operator(
+               operators,
+               operator.owner,
+               operator.operator,
+               operator.token_id
+            )
+         when (Remove_operator(operator)):
+            remove_operator(
+               operators,
+               operator.owner,
+               operator.operator,
+               operator.token_id
+            )
+      };
+   let operators = get_operators(s);
+   operators = List.fold_left(update_operator, operators, updates);
+   const store = set_operators([s, operators]);
+   return [list([]), store]
 };
 
 export const get_balance = <T>(p: [address, nat], s: storage<T>): nat => {
-  const [owner, token_id] = p;
-  Assertions.assert_token_exist(s.token_metadata, token_id);
-  if (is_owner_of(s.ledger, token_id, owner)) {
-     return 1n
-  } else {
-     return 0n
-  }
+   const [owner, token_id] = p;
+   Assertions.assert_token_exist(s.token_metadata, token_id);
+   if (is_owner_of(s.ledger, token_id, owner)) {
+      return 1n
+   } else {
+      return 0n
+   }
 };
 
 export const total_supply = <T>(token_id: nat, s: storage<T>): nat => {
-  Assertions.assert_token_exist(s.token_metadata, token_id);
-  return 1n
+   Assertions.assert_token_exist(s.token_metadata, token_id);
+   return 1n
 };
 
 export const all_tokens = <T>(_: unit, _s: storage<T>): set<nat> =>
-  failwith(Errors.not_available);
+   failwith(Errors.not_available);
 
 export const is_operator = <T>(op: TZIP12.operator, s: storage<T>): bool => {
-  const authorized =
-     match(Big_map.find_opt([op.owner, op.operator], s.operators)) {
-        when (Some(a)):
-           a
-        when (None()):
-           Set.empty
-     };
-  return (Set.mem(op.token_id, authorized) || op.owner == op.operator)
+   const authorized =
+      match(Big_map.find_opt([op.owner, op.operator], s.operators)) {
+         when (Some(a)):
+            a
+         when (None()):
+            Set.empty
+      };
+   return (Set.mem(op.token_id, authorized) || op.owner == op.operator)
 };
 
-export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.tokenMetadataData => {
-  return match(Big_map.find_opt(p, s.token_metadata)) {
-     when (Some(data)):
-        data
-     when (None()):
-        failwith(Errors.undefined_token)
-  }
+export const token_metadata = <T>(p: nat, s: storage<T>): TZIP12.
+tokenMetadataData => {
+   return match(Big_map.find_opt(p, s.token_metadata)) {
+      when (Some(data)):
+         data
+      when (None()):
+         failwith(Errors.undefined_token)
+   }
 }

--- a/lib/fa2/nft/extendable_nft.impl.mligo
+++ b/lib/fa2/nft/extendable_nft.impl.mligo
@@ -12,17 +12,16 @@ type operators = ((address * operator), nat set) big_map
 
 type 'a storage =
   {
-   extension: 'a;
+   extension : 'a;
    ledger : ledger;
    operators : operators;
    token_metadata : TZIP12.tokenMetadata;
-   metadata : TZIP16.metadata;
+   metadata : TZIP16.metadata
   }
 
 type 'a ret = operation list * 'a storage
 
 // Operators
-
 let assert_authorisation
   (operators : operators)
   (from_ : address)
@@ -39,8 +38,7 @@ let assert_authorisation
     if Set.mem token_id authorized then () else failwith Errors.not_operator
 
 let is_operator
-  (operators, owner, operator, token_id
-   : (operators * address * address * nat))
+  (operators, owner, operator, token_id : (operators * address * address * nat))
 : bool =
   let authorized =
     match Big_map.find_opt (owner, operator) operators with
@@ -57,7 +55,6 @@ let add_operator
   if owner = operator
   then operators
   (* assert_authorisation always allow the owner so this case is not relevant *)
-
   else
     let () = Assertions.assert_update_permission owner in
     let auth_tokens =
@@ -76,7 +73,6 @@ let remove_operator
   if owner = operator
   then operators
   (* assert_authorisation always allow the owner so this case is not relevant *)
-
   else
     let () = Assertions.assert_update_permission owner in
     let auth_tokens =
@@ -90,13 +86,11 @@ let remove_operator
     Big_map.update (owner, operator) auth_tokens operators
 
 //module Ledger = struct
-
 let is_owner_of (ledger : ledger) (token_id : nat) (owner : address) : bool =
   let current_owner = Option.unopt (Big_map.find_opt token_id ledger) in
   current_owner = owner
 
-let assert_owner_of (ledger : ledger) (token_id : nat) (owner : address)
-: unit =
+let assert_owner_of (ledger : ledger) (token_id : nat) (owner : address) : unit =
   assert_with_error (is_owner_of ledger token_id owner) Errors.ins_balance
 
 let transfer_token_from_user_to_user
@@ -110,29 +104,30 @@ let transfer_token_from_user_to_user
   ledger
 
 //module Storage = struct
+let is_owner_of (type a) (s : a storage) (owner : address) (token_id : nat)
+: bool = is_owner_of s.ledger token_id owner
 
-let is_owner_of (type a) (s : a storage) (owner : address) (token_id : nat) : bool =
-  is_owner_of s.ledger token_id owner
-
-let set_ledger (type a) (s : a storage) (ledger : ledger) = {s with ledger = ledger}
+let set_ledger (type a) (s : a storage) (ledger : ledger) =
+  {s with ledger = ledger}
 
 let get_operators (type a) (s : a storage) = s.operators
 
 let set_operators (type a) (s : a storage) (operators : operators) =
   {s with operators = operators}
 
-let get_balance (type a) (s : a storage) (owner : address) (token_id : nat) : nat =
+let get_balance (type a) (s : a storage) (owner : address) (token_id : nat)
+: nat =
   let () = Assertions.assert_token_exist s.token_metadata token_id in
   if is_owner_of s owner token_id then 1n else 0n
 
-let set_balance (type a) (s : a storage) (owner : address) (token_id : nat) : a storage =
+let set_balance (type a) (s : a storage) (owner : address) (token_id : nat)
+: a storage =
   let () = Assertions.assert_token_exist s.token_metadata token_id in
   let new_ledger = Big_map.update token_id (Some owner) s.ledger in
   set_ledger s new_ledger
 
 let transfer (type a) (t : TZIP12.transfer) (s : a storage) : a ret =
   (* This function process the "txs" list. Since all transfer share the same "from_" address, we use a se *)
-
   let process_atomic_transfer
     (from_ : address)
     (ledger, t : ledger * TZIP12.atomic_trans) =
@@ -175,7 +170,10 @@ let balance_of (type a) (b : TZIP12.balance_of) (s : a storage) : a ret =
   let operation = Tezos.transaction (Main callback_param) 0mutez callback in
   ([operation] : operation list), s
 
-let update_operators (type a) (updates : TZIP12.update_operators) (s : a storage) : a ret =
+let update_operators (type a)
+  (updates : TZIP12.update_operators)
+  (s : a storage)
+: a ret =
   let update_operator (operators, update : operators * TZIP12.unit_update) =
     match update with
       Add_operator
@@ -219,5 +217,3 @@ let token_metadata (type a) (p : nat) (s : a storage) : TZIP12.tokenMetadataData
   match Big_map.find_opt p s.token_metadata with
     Some (data) -> data
   | None () -> failwith Errors.undefined_token
-
-

--- a/lib/fa2/nft/extendable_nft.impl.mligo
+++ b/lib/fa2/nft/extendable_nft.impl.mligo
@@ -21,6 +21,15 @@ type 'a storage =
 
 type 'a ret = operation list * 'a storage
 
+let make_storage (type a) (extension : a) : a storage =
+  {
+   ledger = Big_map.empty;
+   operators = Big_map.empty;
+   token_metadata = Big_map.empty;
+   metadata = Big_map.empty;
+   extension = extension
+  }
+
 // Operators
 let assert_authorisation
   (operators : operators)

--- a/lib/fa2/nft/nft.impl.jsligo
+++ b/lib/fa2/nft/nft.impl.jsligo
@@ -1,19 +1,34 @@
 #import "../common/assertions.jsligo" "Assertions"
+
 #import "../common/errors.mligo" "Errors"
+
 #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+
 #import "../common/tzip16.datatypes.jsligo" "TZIP16"
+
 #import "./extendable_nft.impl.jsligo" "NFTExtendable"
 
 export type ledger = NFTExtendable.ledger;
+
 export type operator = NFTExtendable.operator;
+
 export type operators = NFTExtendable.operators;
+
 export type storage = {
-  ledger : ledger,
-  operators : operators,
-  token_metadata : TZIP12.tokenMetadata,
-  metadata : TZIP16.metadata,
+  ledger: ledger,
+  operators: operators,
+  token_metadata: TZIP12.tokenMetadata,
+  metadata: TZIP16.metadata,
 }
+
 type ret = [list<operation>, storage];
+
+const empty_storage: storage = {
+  ledger: Big_map.empty,
+  operators: Big_map.empty,
+  token_metadata: Big_map.empty,
+  metadata: Big_map.empty
+}
 
 @inline
 const lift = (s: storage): NFTExtendable.storage<unit> => {

--- a/lib/fa2/nft/nft.impl.mligo
+++ b/lib/fa2/nft/nft.impl.mligo
@@ -11,23 +11,32 @@ type operator = NFTExtendable.operator
 
 type operators = NFTExtendable.operators
 
-type storage = {
+type storage =
+  {
    ledger : ledger;
    operators : operators;
    token_metadata : TZIP12.tokenMetadata;
-   metadata : TZIP16.metadata;
-}
+   metadata : TZIP16.metadata
+  }
 
 type ret = operation list * storage
+
+let empty_storage : storage =
+  {
+   ledger = Big_map.empty;
+   operators = Big_map.empty;
+   token_metadata = Big_map.empty;
+   metadata = Big_map.empty
+  }
 
 [@inline]
 let lift (s : storage) : unit NFTExtendable.storage =
   {
-    ledger = s.ledger;
-    operators = s.operators;
-    token_metadata = s.token_metadata;
-    metadata = s.metadata;
-    extension = ();
+   ledger = s.ledger;
+   operators = s.operators;
+   token_metadata = s.token_metadata;
+   metadata = s.metadata;
+   extension = ()
   }
 
 [@inline]
@@ -35,10 +44,10 @@ let unlift (ret : operation list * unit NFTExtendable.storage) : ret =
   let ops, s = ret in
   ops,
   {
-    ledger = s.ledger;
-    operators = s.operators;
-    token_metadata = s.token_metadata;
-    metadata = s.metadata;
+   ledger = s.ledger;
+   operators = s.operators;
+   token_metadata = s.token_metadata;
+   metadata = s.metadata
   }
 
 [@entry]

--- a/test/fa2/multi_asset.test.mligo
+++ b/test/fa2/multi_asset.test.mligo
@@ -112,7 +112,7 @@ let assert_balances
 (* Transfer *)
 
 (* 1. transfer successful *)
-let test_atomic_tansfer_success =
+let test_atomic_transfer_success =
   let initial_storage, owners, operators = get_initial_storage (10n, 10n, 10n) in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
@@ -189,7 +189,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   | Fail _ -> failwith "invalid test failure"
 
 (* 5. transfer successful 0 amount & self transfer *)
-let test_atomic_tansfer_success_zero_amount_and_self_transfer =
+let test_atomic_transfer_success_zero_amount_and_self_transfer =
   let initial_storage, owners, operators = get_initial_storage (10n, 10n, 10n) in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in

--- a/test/fa2/multi_asset_jsligo.test.mligo
+++ b/test/fa2/multi_asset_jsligo.test.mligo
@@ -112,7 +112,7 @@ let assert_balances
 (* Transfer *)
 
 (* 1. transfer successful *)
-let test_atomic_tansfer_success =
+let test_atomic_transfer_success =
   let initial_storage, owners, operators = get_initial_storage (10n, 10n, 10n) in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
@@ -189,7 +189,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   | Fail _ -> failwith "invalid test failure"
 
 (* 5. transfer successful 0 amount & self transfer *)
-let test_atomic_tansfer_success_zero_amount_and_self_transfer =
+let test_atomic_transfer_success_zero_amount_and_self_transfer =
   let initial_storage, owners, operators = get_initial_storage (10n, 10n, 10n) in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in

--- a/test/fa2/nft/e2e_mutation.test.mligo
+++ b/test/fa2/nft/e2e_mutation.test.mligo
@@ -1,33 +1,39 @@
 #import "../../../lib/fa2/nft/nft.impl.mligo" "FA2_NFT"
 #import "./nft.test.mligo" "Test_FA2_NFT"
- 
+
 let originate_and_test_e2e contract =
-  let () = Test_FA2_NFT._test_atomic_tansfer_operator_success contract in
-  let () = Test_FA2_NFT._test_atomic_tansfer_owner_success contract in
+  let () = Test_FA2_NFT._test_atomic_transfer_operator_success contract in
+  let () = Test_FA2_NFT._test_atomic_transfer_owner_success contract in
   let () = Test_FA2_NFT._test_transfer_token_undefined contract in
   let () = Test_FA2_NFT._test_atomic_transfer_failure_not_operator contract in
-  let () = Test_FA2_NFT._test_atomic_tansfer_success_zero_amount_and_self_transfer contract in
+  let () =
+    Test_FA2_NFT._test_atomic_transfer_success_zero_amount_and_self_transfer
+      contract in
   let () = Test_FA2_NFT._test_transfer_failure_transitive_operators contract in
   let () = Test_FA2_NFT._test_empty_transfer_and_balance_of contract in
   let () = Test_FA2_NFT._test_balance_of_token_undefines contract in
   let () = Test_FA2_NFT._test_balance_of_requests_with_duplicates contract in
-  let () = Test_FA2_NFT._test_balance_of_0_balance_if_address_does_not_hold_tokens contract in
-  let () = Test_FA2_NFT._test_update_operator_remove_operator_and_transfer contract in
+  let () =
+    Test_FA2_NFT._test_balance_of_0_balance_if_address_does_not_hold_tokens
+      contract in
+  let () =
+    Test_FA2_NFT._test_update_operator_remove_operator_and_transfer contract in
   let () = Test_FA2_NFT._test_update_operator_add_operator_and_transfer contract in
   let () = Test_FA2_NFT._test_only_sender_manage_operators contract in
-  let () = Test_FA2_NFT._test_update_operator_remove_operator_and_transfer1 contract in
-  let () = Test_FA2_NFT._test_update_operator_add_operator_and_transfer1 contract in
+  let () =
+    Test_FA2_NFT._test_update_operator_remove_operator_and_transfer1 contract in
+  let () =
+    Test_FA2_NFT._test_update_operator_add_operator_and_transfer1 contract in
   ()
 
 let test_mutation =
-
-  match Test.mutation_test_all (contract_of FA2_NFT.NFT) originate_and_test_e2e with
-
+  match Test.mutation_test_all (contract_of  FA2_NFT.NFT) originate_and_test_e2e
+  with
     [] -> ()
   | ms ->
-    let () = List.iter 
-      (fun ((_, mutation) : unit * mutation) ->
-        let () = Test.log mutation in 
-        ()
-      ) ms in
-    Test.failwith "Some mutation also passes the tests! ^^"
+      let () =
+        List.iter
+          (fun ((_, mutation) : unit * mutation) -> let () = Test.log mutation in
+             ())
+          ms in
+      Test.failwith "Some mutation also passes the tests! ^^"

--- a/test/fa2/nft/nft.test.mligo
+++ b/test/fa2/nft/nft.test.mligo
@@ -12,7 +12,7 @@ type fa2_nft = (FA2_NFT parameter_of, FA2_NFT.storage) module_contract
 (* Transfer *)
 
 (* 1. transfer successful *)
-let _test_atomic_tansfer_operator_success (contract: fa2_nft) =
+let _test_atomic_transfer_operator_success (contract: fa2_nft) =
   let initial_storage, owners, operators = TestHelpers.get_initial_storage () in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
@@ -29,11 +29,11 @@ let _test_atomic_tansfer_operator_success (contract: fa2_nft) =
   let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
 
-let test_atomic_tansfer_operator_success = _test_atomic_tansfer_operator_success (contract_of FA2_NFT)
+let test_atomic_transfer_operator_success = _test_atomic_transfer_operator_success (contract_of FA2_NFT)
 
 
 (* 1.1. transfer successful owner *)
-let _test_atomic_tansfer_owner_success (contract: fa2_nft) =
+let _test_atomic_transfer_owner_success (contract: fa2_nft) =
   let initial_storage, owners, _ = TestHelpers.get_initial_storage () in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
@@ -49,7 +49,7 @@ let _test_atomic_tansfer_owner_success (contract: fa2_nft) =
   let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
 
-let test_atomic_tansfer_owner_success = _test_atomic_tansfer_owner_success (contract_of FA2_NFT)
+let test_atomic_transfer_owner_success = _test_atomic_transfer_owner_success (contract_of FA2_NFT)
 
 
 (* 2. transfer failure token undefined *)
@@ -91,7 +91,7 @@ let test_atomic_transfer_failure_not_operator
   = _test_atomic_transfer_failure_not_operator (contract_of FA2_NFT)
 
 (* 4. self transfer *)
-let _test_atomic_tansfer_success_zero_amount_and_self_transfer (contract: fa2_nft) =
+let _test_atomic_transfer_success_zero_amount_and_self_transfer (contract: fa2_nft) =
   let initial_storage, owners, _operators = TestHelpers.get_initial_storage () in
 
   let owner1 = List_helper.nth_exn 0 owners in
@@ -107,9 +107,9 @@ let _test_atomic_tansfer_success_zero_amount_and_self_transfer (contract: fa2_nf
   let _ = Test.transfer_exn orig.addr (Transfer transfer_requests) 0tez in
   let () = TestHelpers.assert_balances orig.addr ((owner1, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
-let test_atomic_tansfer_success_zero_amount_and_self_transfer =
+let test_atomic_transfer_success_zero_amount_and_self_transfer =
 
-  _test_atomic_tansfer_success_zero_amount_and_self_transfer (contract_of FA2_NFT)
+  _test_atomic_transfer_success_zero_amount_and_self_transfer (contract_of FA2_NFT)
 
 
 (* 5. transfer failure transitive operators *)

--- a/test/fa2/nft/nft_jsligo.test.mligo
+++ b/test/fa2/nft/nft_jsligo.test.mligo
@@ -6,7 +6,7 @@
 type return = operation list * FA2_NFT.storage
 (* Transfer *)
 (* 1. transfer successful *)
-let _test_atomic_tansfer_operator_success () =
+let _test_atomic_transfer_operator_success () =
   let initial_storage, owners, operators = TestHelpers.get_initial_storage () in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
@@ -22,9 +22,9 @@ let _test_atomic_tansfer_operator_success () =
   let _ = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
-let test_atomic_tansfer_operator_success = _test_atomic_tansfer_operator_success ()
+let test_atomic_transfer_operator_success = _test_atomic_transfer_operator_success ()
 (* 1.1. transfer successful owner *)
-let _test_atomic_tansfer_owner_success () =
+let _test_atomic_transfer_owner_success () =
   let initial_storage, owners, _ = TestHelpers.get_initial_storage () in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
@@ -39,7 +39,7 @@ let _test_atomic_tansfer_owner_success () =
   let _ = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   let () = TestHelpers.assert_balances orig.addr ((owner2, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
-let test_atomic_tansfer_owner_success = _test_atomic_tansfer_owner_success ()
+let test_atomic_transfer_owner_success = _test_atomic_transfer_owner_success ()
 (* 2. transfer failure token undefined *)
 let _test_transfer_token_undefined () =
   let initial_storage, owners, operators = TestHelpers.get_initial_storage () in
@@ -74,7 +74,7 @@ let _test_atomic_transfer_failure_not_operator () =
 let test_atomic_transfer_failure_not_operator
   = _test_atomic_transfer_failure_not_operator ()
 (* 4. self transfer *)
-let _test_atomic_tansfer_success_zero_amount_and_self_transfer () =
+let _test_atomic_transfer_success_zero_amount_and_self_transfer () =
   let initial_storage, owners, operators = TestHelpers.get_initial_storage () in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
@@ -90,8 +90,8 @@ let _test_atomic_tansfer_success_zero_amount_and_self_transfer () =
   let _ = Test.transfer orig.addr (Transfer transfer_requests) 0tez in
   let () = TestHelpers.assert_balances orig.addr ((owner1, 1n), (owner2, 2n), (owner3, 3n)) in
   ()
-let test_atomic_tansfer_success_zero_amount_and_self_transfer =
-  _test_atomic_tansfer_success_zero_amount_and_self_transfer ()
+let test_atomic_transfer_success_zero_amount_and_self_transfer =
+  _test_atomic_transfer_success_zero_amount_and_self_transfer ()
 (* 5. transfer failure transitive operators *)
 let _test_transfer_failure_transitive_operators () =
   let initial_storage, owners, operators = TestHelpers.get_initial_storage () in

--- a/test/fa2/single_asset.test.mligo
+++ b/test/fa2/single_asset.test.mligo
@@ -112,7 +112,7 @@ let assert_balances
 (* Transfer *)
 
 (* 1. transfer successful *)
-let test_atomic_tansfer_success =
+let test_atomic_transfer_success =
   let initial_storage, owners, operators = get_initial_storage (10n, 10n, 10n) in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
@@ -173,7 +173,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   | Fail _ -> failwith "invalid test failure"
 
 (* 4. transfer successful 0 amount & self transfer *)
-let test_atomic_tansfer_success_zero_amount_and_self_transfer =
+let test_atomic_transfer_success_zero_amount_and_self_transfer =
   let initial_storage, owners, operators = get_initial_storage (10n, 10n, 10n) in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in

--- a/test/fa2/single_asset_jsligo.test.mligo
+++ b/test/fa2/single_asset_jsligo.test.mligo
@@ -111,7 +111,7 @@ let assert_balances
 (* Transfer *)
 
 (* 1. transfer successful *)
-let test_atomic_tansfer_success =
+let test_atomic_transfer_success =
   let initial_storage, owners, operators = get_initial_storage (10n, 10n, 10n) in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in
@@ -171,7 +171,7 @@ let test_atomic_transfer_failure_not_suffient_balance =
   | Fail _ -> failwith "invalid test failure"
 
 (* 4. transfer successful 0 amount & self transfer *)
-let test_atomic_tansfer_success_zero_amount_and_self_transfer =
+let test_atomic_transfer_success_zero_amount_and_self_transfer =
   let initial_storage, owners, operators = get_initial_storage (10n, 10n, 10n) in
   let owner1 = List_helper.nth_exn 0 owners in
   let owner2 = List_helper.nth_exn 1 owners in


### PR DESCRIPTION
This is a fork from the PR #38 , this PR add:
- add the `empty_storage`, `make_storage` in `.jsligo` and folder `nft` (`mligo and jsligo`).
- Formatting the code
- Correct spelling `tansfer` to `transfer` in some tests 