### PR TITLE
[chore] sync layout between jsligo and cameligo NFT storage

### DIFF
--- a/lib/fa2/nft/extendable_nft.impl.jsligo
+++ b/lib/fa2/nft/extendable_nft.impl.jsligo
@@ -14,11 +14,11 @@ export type operators = big_map<[address, operator], set<nat>>; //[owner,operato
 
 
 export type storage<T> = {
+   extension: T,
    ledger: ledger,
    operators: operators,
    token_metadata: TZIP12.tokenMetadata,
-   metadata: TZIP16.metadata,
-   extension: T
+   metadata: TZIP16.metadata
 };
 
 type ret<T> = [list<operation>, storage<T>];


### PR DESCRIPTION
Storage layout was different between NFT jsligo and cameligo. Can generate issue between interop of the both files