### PR TITLE
[❌ DO NOT MERGE] chore(deps): bump LIGO to version 1.5.0

### DIFF
--- a/lib/fa2.1/fa2.1-generic.jsligo
+++ b/lib/fa2.1/fa2.1-generic.jsligo
@@ -3,24 +3,22 @@
  * This implementation of FA2.1 norm is work in progress, this implementation is not yet ready for production.
  */
 
-#import "./data/errors.jsligo" "Errors"
-#import "./data/metadata.jsligo" "Metadata"
-#import "./data/token.jsligo" "Token"
-#import "./data/ledger.jsligo" "Ledger"
-#import "./data/operators.jsligo" "Operators"
-#import "./data/approvals.jsligo" "Approvals"
-#import "./data/tokenMetadata.jsligo" "TokenMetadata"
-#import "./data/storage.jsligo" "Storage"
-
-#import "./entrypoints/transfer.jsligo" "Transfer"
-#import "./entrypoints/balance_of.jsligo" "Balance_of"
-#import "./entrypoints/update.jsligo" "Update"
-#import "./entrypoints/approve.jsligo" "Approve"
-#import "./entrypoints/export_ticket.jsligo" "Export_ticket"
-#import "./entrypoints/lambda_export.jsligo" "Lambda_export"
-#import "./entrypoints/import_ticket.jsligo" "Import_ticket"
-
-#import "views.jsligo" "Views"
+export #import "./data/errors.jsligo" "Errors"
+export #import "./data/metadata.jsligo" "Metadata"
+export #import "./data/token.jsligo" "Token"
+export #import "./data/ledger.jsligo" "Ledger"
+export #import "./data/operators.jsligo" "Operators"
+export #import "./data/approvals.jsligo" "Approvals"
+export #import "./data/tokenMetadata.jsligo" "TokenMetadata"
+export #import "./data/storage.jsligo" "Storage"
+export #import "./entrypoints/transfer.jsligo" "Transfer"
+export #import "./entrypoints/balance_of.jsligo" "Balance_of"
+export #import "./entrypoints/update.jsligo" "Update"
+export #import "./entrypoints/approve.jsligo" "Approve"
+export #import "./entrypoints/export_ticket.jsligo" "Export_ticket"
+export #import "./entrypoints/lambda_export.jsligo" "Lambda_export"
+export #import "./entrypoints/import_ticket.jsligo" "Import_ticket"
+export #import "views.jsligo" "Views"
 
 type LedgerModule = Ledger.ledger_module;
 export type Storage = Storage.T;

--- a/lib/fa2/asset/extendable_multi_asset.impl.jsligo
+++ b/lib/fa2/asset/extendable_multi_asset.impl.jsligo
@@ -1,10 +1,7 @@
-#import "../common/assertions.jsligo" "Assertions"
-
-#import "../common/errors.mligo" "Errors"
-
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+export #import "../common/assertions.jsligo" "Assertions"
+export #import "../common/errors.mligo" "Errors"
+export #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+export #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 export type ledger = big_map<[address, nat], nat>;
 

--- a/lib/fa2/asset/extendable_multi_asset.impl.mligo
+++ b/lib/fa2/asset/extendable_multi_asset.impl.mligo
@@ -1,7 +1,7 @@
-#import "../common/assertions.jsligo" "Assertions"
-#import "../common/errors.mligo" "Errors"
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+[@public] #import "../common/assertions.jsligo" "Assertions"
+[@public] #import "../common/errors.mligo" "Errors"
+[@public] #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+[@public] #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 type ledger = ((address * nat), nat) big_map
 

--- a/lib/fa2/asset/extendable_single_asset.impl.jsligo
+++ b/lib/fa2/asset/extendable_single_asset.impl.jsligo
@@ -1,10 +1,7 @@
-#import "../common/assertions.jsligo" "Assertions"
-
-#import "../common/errors.mligo" "Errors"
-
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+export #import "../common/assertions.jsligo" "Assertions"
+export #import "../common/errors.mligo" "Errors"
+export #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+export #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 export type ledger = big_map<address, nat>;
 

--- a/lib/fa2/asset/extendable_single_asset.impl.mligo
+++ b/lib/fa2/asset/extendable_single_asset.impl.mligo
@@ -1,7 +1,7 @@
-#import "../common/assertions.jsligo" "Assertions"
-#import "../common/errors.mligo" "Errors"
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+[@public] #import "../common/assertions.jsligo" "Assertions"
+[@public] #import "../common/errors.mligo" "Errors"
+[@public] #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+[@public] #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 type ledger = (address, nat) big_map
 

--- a/lib/fa2/asset/multi_asset.impl.jsligo
+++ b/lib/fa2/asset/multi_asset.impl.jsligo
@@ -1,10 +1,7 @@
-#import "../common/assertions.jsligo" "Assertions"
-
-#import "../common/errors.mligo" "Errors"
-
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+export #import "../common/assertions.jsligo" "Assertions"
+export #import "../common/errors.mligo" "Errors"
+export #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+export #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 #import "./extendable_multi_asset.impl.jsligo" "MultiAssetExtendable"
 

--- a/lib/fa2/asset/multi_asset.impl.mligo
+++ b/lib/fa2/asset/multi_asset.impl.mligo
@@ -1,8 +1,8 @@
-#import "../common/assertions.jsligo" "Assertions"
-#import "../common/errors.mligo" "Errors"
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-#import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+[@public] #import "../common/assertions.jsligo" "Assertions"
+[@public] #import "../common/errors.mligo" "Errors"
+[@public] #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+[@public] #import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
+[@public] #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 #import "./extendable_multi_asset.impl.mligo" "MultiAssetExtendable"
 
 type ledger = MultiAssetExtendable.ledger

--- a/lib/fa2/asset/single_asset.impl.jsligo
+++ b/lib/fa2/asset/single_asset.impl.jsligo
@@ -1,12 +1,8 @@
-#import "../common/assertions.jsligo" "Assertions"
-
-#import "../common/errors.mligo" "Errors"
-
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-
-#import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
-
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+export #import "../common/assertions.jsligo" "Assertions"
+export #import "../common/errors.mligo" "Errors"
+export #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+export #import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
+export #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 #import "./extendable_single_asset.impl.jsligo" "SingleAssetExtendable"
 

--- a/lib/fa2/asset/single_asset.impl.mligo
+++ b/lib/fa2/asset/single_asset.impl.mligo
@@ -1,8 +1,8 @@
-#import "../common/assertions.jsligo" "Assertions"
-#import "../common/errors.mligo" "Errors"
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-#import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+[@public] #import "../common/assertions.jsligo" "Assertions"
+[@public] #import "../common/errors.mligo" "Errors"
+[@public] #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+[@public] #import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
+[@public] #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 #import "./extendable_single_asset.impl.mligo" "SingleAssetExtendable"
 
 type ledger = SingleAssetExtendable.ledger

--- a/lib/fa2/nft/extendable_nft.impl.jsligo
+++ b/lib/fa2/nft/extendable_nft.impl.jsligo
@@ -1,10 +1,7 @@
-#import "../common/assertions.jsligo" "Assertions"
-
-#import "../common/errors.mligo" "Errors"
-
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+export #import "../common/assertions.jsligo" "Assertions"
+export #import "../common/errors.mligo" "Errors"
+export #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+export #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 export type ledger = big_map<nat, address>;
 

--- a/lib/fa2/nft/extendable_nft.impl.mligo
+++ b/lib/fa2/nft/extendable_nft.impl.mligo
@@ -1,8 +1,8 @@
-#import "../common/assertions.jsligo" "Assertions"
-#import "../common/errors.mligo" "Errors"
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-#import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+[@public] #import "../common/assertions.jsligo" "Assertions"
+[@public] #import "../common/errors.mligo" "Errors"
+[@public] #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+[@public] #import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
+[@public] #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 type ledger = (nat, address) big_map
 

--- a/lib/fa2/nft/nft.impl.jsligo
+++ b/lib/fa2/nft/nft.impl.jsligo
@@ -1,10 +1,7 @@
-#import "../common/assertions.jsligo" "Assertions"
-
-#import "../common/errors.mligo" "Errors"
-
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+export #import "../common/assertions.jsligo" "Assertions"
+export #import "../common/errors.mligo" "Errors"
+export #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+export #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 
 #import "./extendable_nft.impl.jsligo" "NFTExtendable"
 

--- a/lib/fa2/nft/nft.impl.mligo
+++ b/lib/fa2/nft/nft.impl.mligo
@@ -1,8 +1,8 @@
-#import "../common/assertions.jsligo" "Assertions"
-#import "../common/errors.mligo" "Errors"
-#import "../common/tzip12.datatypes.jsligo" "TZIP12"
-#import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
-#import "../common/tzip16.datatypes.jsligo" "TZIP16"
+[@public] #import "../common/assertions.jsligo" "Assertions"
+[@public] #import "../common/errors.mligo" "Errors"
+[@public] #import "../common/tzip12.datatypes.jsligo" "TZIP12"
+[@public] #import "../common/tzip12.interfaces.jsligo" "TZIP12Interface"
+[@public] #import "../common/tzip16.datatypes.jsligo" "TZIP16"
 #import "./extendable_nft.impl.mligo" "NFTExtendable"
 
 type ledger = NFTExtendable.ledger

--- a/lib/main.jsligo
+++ b/lib/main.jsligo
@@ -1,11 +1,11 @@
 // An implementaion of FA2 Interface (TZIP-12) for NFT
-#import "./fa2/nft/nft.impl.jsligo" "NFT"
-#import "./fa2/nft/extendable_nft.impl.jsligo" "NFTExtendable"
+export #import "./fa2/nft/nft.impl.jsligo" "NFT"
+export #import "./fa2/nft/extendable_nft.impl.jsligo" "NFTExtendable"
 
 // An implementaion of FA2 Interface (TZIP-12) for a Single Asset Token
-#import "./fa2/asset/single_asset.impl.jsligo" "SingleAsset"
-#import "./fa2/asset/extendable_single_asset.impl.jsligo" "SingleAssetExtendable"
+export #import "./fa2/asset/single_asset.impl.jsligo" "SingleAsset"
+export #import "./fa2/asset/extendable_single_asset.impl.jsligo" "SingleAssetExtendable"
 
 // An implementaion of FA2 Interface (TZIP-12) for a Multi Asset Token
-#import "./fa2/asset/multi_asset.impl.jsligo" "MultiAsset"
-#import "./fa2/asset/extendable_multi_asset.impl.jsligo" "MultiAssetExtendable"
+export #import "./fa2/asset/multi_asset.impl.jsligo" "MultiAsset"
+export #import "./fa2/asset/extendable_multi_asset.impl.jsligo" "MultiAssetExtendable"

--- a/lib/main.mligo
+++ b/lib/main.mligo
@@ -1,11 +1,11 @@
 (* An implementaion of FA2 Interface (TZIP-12) for NFT *)
-#import "./fa2/nft/nft.impl.mligo" "NFT"
-#import "./fa2/nft/extendable_nft.impl.mligo" "NFTExtendable"
+[@public] #import "./fa2/nft/nft.impl.mligo" "NFT"
+[@public] #import "./fa2/nft/extendable_nft.impl.mligo" "NFTExtendable"
 
 (* An implementaion of FA2 Interface (TZIP-12) for a Single Asset Token *)
-#import "./fa2/asset/single_asset.impl.mligo" "SingleAsset"
-#import "./fa2/asset/extendable_single_asset.impl.mligo" "SingleAssetExtendable"
+[@public] #import "./fa2/asset/single_asset.impl.mligo" "SingleAsset"
+[@public] #import "./fa2/asset/extendable_single_asset.impl.mligo" "SingleAssetExtendable"
 
 (* An implementaion of FA2 Interface (TZIP-12) for a Multi Asset Token *)
-#import "./fa2/asset/multi_asset.impl.mligo" "MultiAsset"
-#import "./fa2/asset/extendable_multi_asset.impl.mligo" "MultiAssetExtendable"
+[@public] #import "./fa2/asset/multi_asset.impl.mligo" "MultiAsset"
+[@public] #import "./fa2/asset/extendable_multi_asset.impl.mligo" "MultiAssetExtendable"


### PR DESCRIPTION
**DO NOT MERGE UNTIL LIGO 1.5.0 IS RELEASED**

# Context

Related issues: [#2160](https://gitlab.com/ligolang/ligo/-/issues/2160)

Following [!3112](https://gitlab.com/ligolang/ligo/-/merge_requests/3112), the LIGO fa library no-longer compiles -- this is due to the fact that modules that were previously exported using an `#import` no-longer get implicitly exported. 

# Description 

Adds `export` (jsligo) or `[@public]` (mligo) to various `#import`s to ensure the correct library structure is exported

# Manual Testing

```sh
cd ligo
git checkout dev
dune build -p ligo
cd ../contract-catalogue
make compile ligo_compiler=../ligo/_build/default/src/bin/runligo.exe
make test ligo_compiler=../ligo/_build/default/src/bin/runligo.exe
```